### PR TITLE
fix(worker): reject invalid plays

### DIFF
--- a/apps/worker/src/durable-objects/GameStateDurableObject.ts
+++ b/apps/worker/src/durable-objects/GameStateDurableObject.ts
@@ -8,7 +8,8 @@ import {
   type ILobby,
   Lobby,
   Player,
-  type Play
+  type Play,
+  type PlayRejectionReason
 } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
 import { type IttyDurableObjectNamespace } from '../types/itty'
@@ -30,6 +31,10 @@ export type RematchGameResult =
 
 export type UpdateDisplayNameResult =
   { status: 'unknown-player' } | { status: 'updated'; gameState: IGameState }
+
+export type PlayGameResult =
+  | { status: 'rejected'; reason: PlayRejectionReason }
+  | { status: 'updated'; gameState: IGameState }
 
 export class GameStateDurableObject extends createDurable({
   autoPersist: true
@@ -82,11 +87,17 @@ export class GameStateDurableObject extends createDurable({
     return { status: 'created', gameState }
   }
 
-  play(play: Play): IGameState {
+  play(play: Play): PlayGameResult {
     const gameState = this.getInitializedGameState()
+    const rejectionReason = gameState.getPlayRejectionReason(play)
+
+    if (rejectionReason !== undefined) {
+      return { status: 'rejected', reason: rejectionReason }
+    }
+
     gameState.applyPlay(play)
     this.gameState = gameState.toJson()
-    return this.gameState
+    return { status: 'updated', gameState: this.gameState }
   }
 
   rematch(

--- a/apps/worker/src/endpoints/play.ts
+++ b/apps/worker/src/endpoints/play.ts
@@ -1,5 +1,5 @@
 import { status } from 'itty-router'
-import { GameState } from '@knucklebones/common'
+import { GameState, type PlayRejectionReason } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
 import { type BaseRequestWithProps } from '../types/itty'
 import { makeAiPlay } from '../utils/ai'
@@ -7,6 +7,7 @@ import {
   broadcastGameState,
   getGameStateDurableObject
 } from '../utils/endpoints'
+import { apiError } from '../utils/http'
 
 interface PlayRequest extends BaseRequestWithProps {
   dice: number
@@ -24,9 +25,14 @@ export async function play(
     author: request.playerId
   }
 
-  const iGameState = await getGameStateDurableObject(request).play(play)
-  const gameState = GameState.fromJson(iGameState)
-  await broadcastGameState(iGameState, request, cloudflareEnvironment)
+  const result = await getGameStateDurableObject(request).play(play)
+
+  if (result.status === 'rejected') {
+    return playError(result.reason, request.requestId)
+  }
+
+  const gameState = GameState.fromJson(result.gameState)
+  await broadcastGameState(result.gameState, request, cloudflareEnvironment)
 
   if (
     gameState.outcome === 'ongoing' &&
@@ -37,4 +43,51 @@ export async function play(
   }
 
   return status(200)
+}
+
+function playError(reason: PlayRejectionReason, requestId: string): Response {
+  switch (reason) {
+    case 'game-ended':
+      return apiError({
+        status: 409,
+        code: 'GAME_ENDED',
+        message: 'The game has already ended.',
+        requestId
+      })
+    case 'unknown-player':
+      return apiError({
+        status: 403,
+        code: 'PLAYER_NOT_IN_GAME',
+        message: 'Only a player in this game can make a move.',
+        requestId
+      })
+    case 'not-player-turn':
+      return apiError({
+        status: 409,
+        code: 'NOT_PLAYER_TURN',
+        message: "It is not this player's turn.",
+        requestId
+      })
+    case 'unexpected-die':
+      return apiError({
+        status: 409,
+        code: 'DIE_MISMATCH',
+        message: 'The submitted die does not match the current turn.',
+        requestId
+      })
+    case 'invalid-column':
+      return apiError({
+        status: 400,
+        code: 'INVALID_COLUMN',
+        message: 'The column must be an integer between 0 and 2.',
+        requestId
+      })
+    case 'column-full':
+      return apiError({
+        status: 409,
+        code: 'COLUMN_FULL',
+        message: 'The selected column is already full.',
+        requestId
+      })
+  }
 }

--- a/packages/common/src/classes/GameState.ts
+++ b/packages/common/src/classes/GameState.ts
@@ -3,6 +3,7 @@ import {
   type Outcome,
   type Play,
   type OutcomeHistory,
+  type PlayRejectionReason,
   type PlayerOutcome,
   type BoType
 } from '../types'
@@ -94,6 +95,12 @@ export class GameState implements IGameState {
   }
 
   applyPlay(play: Play, giveNextDice = true) {
+    const rejectionReason = this.getPlayRejectionReason(play)
+
+    if (rejectionReason !== undefined) {
+      throw new Error(`Invalid play: ${rejectionReason}.`)
+    }
+
     const [playerOne, playerTwo] = this.getPlayers(play.author)
 
     playerOne.addDice(play.dice, play.column)
@@ -109,6 +116,36 @@ export class GameState implements IGameState {
       this.whoWins()
     } else {
       this.nextTurn(play.author, giveNextDice)
+    }
+  }
+
+  getPlayRejectionReason(play: Play): PlayRejectionReason | undefined {
+    if (this.outcome !== 'ongoing') {
+      return 'game-ended'
+    }
+
+    if (
+      play.author !== this.playerOne.id &&
+      play.author !== this.playerTwo.id
+    ) {
+      return 'unknown-player'
+    }
+
+    if (play.author !== this.nextPlayer.id) {
+      return 'not-player-turn'
+    }
+
+    if (play.dice !== this.nextPlayer.dice) {
+      return 'unexpected-die'
+    }
+
+    if (!Number.isInteger(play.column) || play.column < 0 || play.column > 2) {
+      return 'invalid-column'
+    }
+
+    const [player] = this.getPlayers(play.author)
+    if (player.columns[play.column].length >= 3) {
+      return 'column-full'
     }
   }
 

--- a/packages/common/src/types/play.ts
+++ b/packages/common/src/types/play.ts
@@ -3,3 +3,11 @@ export interface Play {
   column: number
   author: string
 }
+
+export type PlayRejectionReason =
+  | 'game-ended'
+  | 'unknown-player'
+  | 'not-player-turn'
+  | 'unexpected-die'
+  | 'invalid-column'
+  | 'column-full'


### PR DESCRIPTION
## Summary

- centralize move validation in the shared `GameState` rules
- reject unknown players, out-of-turn moves, stale dice, invalid or full columns, and moves after game end
- return stable structured errors without mutating or broadcasting rejected moves
