### PR TITLE
fix(worker): reject client websocket messages

### DIFF
--- a/apps/worker/src/durable-objects/WebSocketDurableObject.ts
+++ b/apps/worker/src/durable-objects/WebSocketDurableObject.ts
@@ -71,12 +71,8 @@ export class WebSocketDurableObject {
     this.state.acceptWebSocket(webSocket)
   }
 
-  async webSocketMessage(webSocket: WebSocket, message: string | ArrayBuffer) {
-    try {
-      this.broadcast(JSON.stringify(message))
-    } catch (error) {
-      this.sentry.captureException(error)
-    }
+  async webSocketMessage(webSocket: WebSocket) {
+    webSocket.close(1008, 'Client messages are not supported.')
   }
 
   async webSocketClose(


### PR DESCRIPTION
## Summary

- stop rebroadcasting arbitrary client-sent WebSocket payloads
- close clients that send unsupported application messages with policy code `1008`
- preserve server-originated room state broadcasts
