### PR TITLE
feat(game): version state mutations

### DIFF
--- a/apps/front/src/components/GameContext/useGameSetup.ts
+++ b/apps/front/src/components/GameContext/useGameSetup.ts
@@ -33,6 +33,7 @@ export function useGameSetup() {
   const [isLoading, setIsLoading] = React.useState(true)
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
   const roomKey = useRoomKey()
+  const latestRevision = React.useRef({ roomKey, value: -1 })
   const state = useLocation().state as GameSettings | undefined
   const { lastJsonMessage, readyState } = useWebSocket(getWebSocketUrl(roomKey))
 
@@ -61,11 +62,44 @@ export function useGameSetup() {
         return
       }
 
+      const hasRevision =
+        typeof lastJsonMessage === 'object' &&
+        lastJsonMessage !== null &&
+        'revision' in lastJsonMessage
+
+      const messageRoomKey =
+        typeof lastJsonMessage === 'object' &&
+        lastJsonMessage !== null &&
+        'roomKey' in lastJsonMessage &&
+        typeof lastJsonMessage.roomKey === 'string'
+          ? lastJsonMessage.roomKey
+          : undefined
+
+      if (messageRoomKey !== undefined && messageRoomKey !== roomKey) {
+        return
+      }
+
+      const latestRoomRevision =
+        latestRevision.current.roomKey === roomKey
+          ? latestRevision.current.value
+          : -1
+
+      if (hasRevision && parsedGameState.data.revision <= latestRoomRevision) {
+        return
+      }
+
+      if (hasRevision) {
+        latestRevision.current = {
+          roomKey,
+          value: parsedGameState.data.revision
+        }
+      }
+
       setGameState(parsedGameState.data)
       setIsLoading(false)
       setErrorMessage(null)
     }
-  }, [lastJsonMessage])
+  }, [lastJsonMessage, roomKey])
 
   React.useEffect(() => {
     if (readyState === ReadyState.OPEN) {

--- a/apps/worker/src/durable-objects/GameStateDurableObject.ts
+++ b/apps/worker/src/durable-objects/GameStateDurableObject.ts
@@ -58,12 +58,13 @@ export class GameStateDurableObject extends createDurable({
   }: InitializeGameCommand): InitializeGameResult {
     if (this.gameState !== undefined) {
       const gameState = GameState.fromJson(this.gameState)
+      let serializedGameState = gameState.toJson()
 
       if (gameState.addSpectator(playerId)) {
-        this.gameState = gameState.toJson()
+        serializedGameState = this.commitGameState(gameState)
       }
 
-      return { status: 'existing', gameState: gameState.toJson() }
+      return { status: 'existing', gameState: serializedGameState }
     }
 
     const lobby = Lobby.fromJson(this.lobby)
@@ -81,8 +82,7 @@ export class GameStateDurableObject extends createDurable({
       return { status: 'waiting' }
     }
 
-    const gameState = lobby.toGameState().toJson()
-    this.gameState = gameState
+    const gameState = this.commitGameState(lobby.toGameState())
 
     return { status: 'created', gameState }
   }
@@ -96,8 +96,7 @@ export class GameStateDurableObject extends createDurable({
     }
 
     gameState.applyPlay(play)
-    this.gameState = gameState.toJson()
-    return { status: 'updated', gameState: this.gameState }
+    return { status: 'updated', gameState: this.commitGameState(gameState) }
   }
 
   rematch(
@@ -127,14 +126,18 @@ export class GameStateDurableObject extends createDurable({
         )
       })
       newGameState.initialize({ ...gameState, ...gameSettings })
-      this.gameState = newGameState.toJson()
-      return { status: 'updated', gameState: this.gameState }
+      return {
+        status: 'updated',
+        gameState: this.commitGameState(newGameState)
+      }
     }
 
     if (gameState.rematchVote === undefined) {
       gameState.rematchVote = playerId
-      this.gameState = gameState.toJson()
-      return { status: 'updated', gameState: this.gameState }
+      return {
+        status: 'updated',
+        gameState: this.commitGameState(gameState)
+      }
     }
 
     return { status: 'unchanged' }
@@ -154,8 +157,16 @@ export class GameStateDurableObject extends createDurable({
       return { status: 'unknown-player' }
     }
 
+    return {
+      status: 'updated',
+      gameState: this.commitGameState(gameState)
+    }
+  }
+
+  private commitGameState(gameState: GameState): IGameState {
+    gameState.revision = (this.gameState?.revision ?? 0) + 1
     this.gameState = gameState.toJson()
-    return { status: 'updated', gameState: this.gameState }
+    return this.gameState
   }
 
   private getInitializedGameState(): GameState {

--- a/apps/worker/src/utils/endpoints.ts
+++ b/apps/worker/src/utils/endpoints.ts
@@ -18,6 +18,6 @@ export async function broadcastGameState(
   return await webSocketStore.fetch('https://dummy-url/broadcast', {
     method: 'POST',
     headers: { 'X-Request-Id': request.requestId },
-    body: JSON.stringify(toGameStateMessage(gameState))
+    body: JSON.stringify(toGameStateMessage(gameState, roomKey))
   })
 }

--- a/packages/common/src/classes/GameState.ts
+++ b/packages/common/src/classes/GameState.ts
@@ -21,6 +21,7 @@ interface GameStateConstructorArg extends Partial<
 }
 
 export class GameState implements IGameState {
+  revision: number
   playerOne: Player
   playerTwo: Player
   spectators: string[]
@@ -40,10 +41,12 @@ export class GameState implements IGameState {
     rematchVote,
     winnerId,
     boType = 'indefinite',
+    revision = 0,
     logs = [],
     spectators = [],
     outcomeHistory = []
   }: GameStateConstructorArg) {
+    this.revision = revision
     this.playerOne = playerOne
     this.playerTwo = playerTwo
     this.logs = logs
@@ -266,6 +269,7 @@ export class GameState implements IGameState {
 
   toJson(): IGameState {
     return {
+      revision: this.revision,
       playerOne: this.playerOne.toJson(),
       playerTwo: this.playerTwo.toJson(),
       logs: this.logs.map((log) => log.toJson()),

--- a/packages/common/src/interfaces/IGameState.ts
+++ b/packages/common/src/interfaces/IGameState.ts
@@ -3,6 +3,7 @@ import { type ILog } from './ILog'
 import { type IPlayer } from './IPlayer'
 
 export interface IGameState {
+  revision: number
   playerOne: IPlayer
   playerTwo: IPlayer
   spectators: string[]

--- a/packages/common/src/schemas/gameState.ts
+++ b/packages/common/src/schemas/gameState.ts
@@ -61,6 +61,7 @@ const outcomeHistoryEntrySchema = z.object({
 }) satisfies z.ZodMiniType<OutcomeHistoryEntry>
 
 export const gameStateSchema = z.object({
+  revision: z._default(z.int().check(z.minimum(0)), 0),
   playerOne: playerSchema,
   playerTwo: playerSchema,
   spectators: z.array(playerIdSchema),

--- a/packages/common/src/schemas/gameStateMessage.ts
+++ b/packages/common/src/schemas/gameStateMessage.ts
@@ -5,11 +5,13 @@ import { gameStateSchema } from './gameState'
 export const GAME_STATE_MESSAGE_VERSION = 1 as const
 
 export type GameStateMessage = IGameState & {
+  roomKey: string
   type: 'game.state'
   version: typeof GAME_STATE_MESSAGE_VERSION
 }
 
 export const gameStateMessageSchema = z.extend(gameStateSchema, {
+  roomKey: z.string().check(z.minLength(1)),
   type: z.literal('game.state'),
   version: z.literal(GAME_STATE_MESSAGE_VERSION)
 }) satisfies z.ZodMiniType<GameStateMessage>
@@ -19,9 +21,13 @@ export const compatibleGameStateMessageSchema = z.union([
   gameStateSchema
 ]) satisfies z.ZodMiniType<IGameState>
 
-export function toGameStateMessage(gameState: IGameState): GameStateMessage {
+export function toGameStateMessage(
+  gameState: IGameState,
+  roomKey: string
+): GameStateMessage {
   return {
     ...gameState,
+    roomKey,
     type: 'game.state',
     version: GAME_STATE_MESSAGE_VERSION
   }


### PR DESCRIPTION
## Summary

- add backward-compatible monotonic revisions to serialized game state
- increment revisions atomically for persisted room mutations
- include room identity in state messages and ignore stale, duplicate, or wrong-room updates in the frontend
