### PR TITLE
feat(front): bootstrap player identity

### DIFF
--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -23,7 +23,6 @@
     "react-i18next": "^17.0.11",
     "react-router-dom": "7.18.2",
     "react-use-websocket": "^4.13.0",
-    "unique-names-generator": "^4.7.1",
     "uuid": "^14.0.1"
   }
 }

--- a/apps/front/src/components/App.tsx
+++ b/apps/front/src/components/App.tsx
@@ -1,20 +1,14 @@
 import * as React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { getPathLanguage } from '../translations'
-import { randomName } from '../utils/name'
 import { Language } from './Language'
+import { PlayerIdentityGate } from './PlayerIdentityGate'
 import { Router } from './Router'
 import { MainContent, SideBarContainer, SideBarLayout } from './SideBar'
 import { Theme } from './Theme'
 
 export function App() {
   const mainContentRef = React.useRef<React.ElementRef<'div'>>(null)
-
-  React.useEffect(() => {
-    if (localStorage.getItem('playerId') === null) {
-      localStorage.setItem('playerId', randomName())
-    }
-  }, [])
 
   return (
     <BrowserRouter basename={getPathLanguage()}>
@@ -31,7 +25,9 @@ export function App() {
           />
 
           <MainContent ref={mainContentRef}>
-            <Router />
+            <PlayerIdentityGate>
+              <Router />
+            </PlayerIdentityGate>
           </MainContent>
         </SideBarLayout>
       </div>

--- a/apps/front/src/components/PlayerIdentityGate.tsx
+++ b/apps/front/src/components/PlayerIdentityGate.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { ensurePlayerIdentity } from '../utils/playerIdentity'
+import { Button } from './Button'
+
+type IdentityStatus = 'loading' | 'ready' | 'error'
+
+export function PlayerIdentityGate({ children }: React.PropsWithChildren) {
+  const [status, setStatus] = React.useState<IdentityStatus>('loading')
+  const { t } = useTranslation()
+
+  const initializeIdentity = React.useCallback(async () => {
+    setStatus('loading')
+
+    try {
+      await ensurePlayerIdentity()
+      setStatus('ready')
+    } catch {
+      setStatus('error')
+    }
+  }, [])
+
+  React.useEffect(() => {
+    void initializeIdentity()
+  }, [initializeIdentity])
+
+  if (status === 'loading') {
+    return (
+      <h2 className='text-center text-3xl font-semibold md:text-5xl'>
+        {t('identity.loading')}
+      </h2>
+    )
+  }
+
+  if (status === 'error') {
+    return (
+      <div className='flex flex-col items-center gap-4 text-center'>
+        <h2 className='text-2xl font-semibold md:text-4xl'>
+          {t('identity.error')}
+        </h2>
+        <Button onClick={() => void initializeIdentity()}>
+          {t('identity.retry')}
+        </Button>
+      </div>
+    )
+  }
+
+  return children
+}

--- a/apps/front/src/translations/resources/en.json
+++ b/apps/front/src/translations/resources/en.json
@@ -77,5 +77,10 @@
       "opponent-win": "{{player}} won the game with {{points}} points!"
     }
   },
-  "loading": "Waiting for game to start"
+  "loading": "Waiting for game to start",
+  "identity": {
+    "loading": "Creating your player identity…",
+    "error": "We couldn't create your player identity.",
+    "retry": "Try again"
+  }
 }

--- a/apps/front/src/translations/resources/fr.json
+++ b/apps/front/src/translations/resources/fr.json
@@ -78,5 +78,10 @@
       "opponent-win": "{{player}} a gagné la partie avec {{points}} points !"
     }
   },
-  "loading": "En attente du début de la partie"
+  "loading": "En attente du début de la partie",
+  "identity": {
+    "loading": "Création de votre identité de joueur…",
+    "error": "Impossible de créer votre identité de joueur.",
+    "retry": "Réessayer"
+  }
 }

--- a/apps/front/src/translations/resources/zh-tw.json
+++ b/apps/front/src/translations/resources/zh-tw.json
@@ -77,5 +77,10 @@
       "opponent-win": "{{player}} 以 {{points}} 分贏了遊戲！"
     }
   },
-  "loading": "等待遊戲開始"
+  "loading": "等待遊戲開始",
+  "identity": {
+    "loading": "正在建立您的玩家身分…",
+    "error": "無法建立您的玩家身分。",
+    "retry": "再試一次"
+  }
 }

--- a/apps/front/src/utils/api.ts
+++ b/apps/front/src/utils/api.ts
@@ -1,6 +1,21 @@
-import { type GameSettings } from '@knucklebones/common'
+import {
+  type GameSettings,
+  type PlayerCredentials,
+  playerCredentialsSchema
+} from '@knucklebones/common'
 
 type Method = 'GET' | 'POST' | 'DELETE'
+
+export async function createPlayer(): Promise<PlayerCredentials> {
+  const response = await sendApiRequest('/players', 'POST')
+  const result = playerCredentialsSchema.safeParse(await response.json())
+
+  if (!result.success) {
+    throw new Error('The server returned invalid player credentials.')
+  }
+
+  return result.data
+}
 
 // À synchroniser avec les types de requêtes côté back
 interface IdentificationParams {
@@ -91,7 +106,7 @@ async function sendApiRequest(path: string, method: Method, body?: unknown) {
     ...(body !== undefined && { 'Content-Type': 'application/json' })
   }
 
-  await fetch(`${import.meta.env.VITE_WORKER_URL}${path}`, {
+  return await fetch(`${import.meta.env.VITE_WORKER_URL}${path}`, {
     method,
     headers,
     ...(body !== undefined && { body: JSON.stringify(body) })
@@ -102,6 +117,7 @@ async function sendApiRequest(path: string, method: Method, body?: unknown) {
           `[${resp.status}:${resp.statusText}] There was an error while doing a network call. Please try again.`
         )
       }
+      return resp
     })
     .catch(() => {
       throw new Error(

--- a/apps/front/src/utils/name.ts
+++ b/apps/front/src/utils/name.ts
@@ -1,32 +1,11 @@
 import { t } from 'i18next'
 import {
-  uniqueNamesGenerator,
-  adjectives,
-  colors,
-  animals
-} from 'unique-names-generator'
-import {
   isEmptyOrBlank,
   type IPlayer,
   type Difficulty
 } from '@knucklebones/common'
 
-// At most, we get a 21 character long name
-const MAX_WORD_LENGTH = 7
-export const MAX_NAME_LENGTH = MAX_WORD_LENGTH * 3
-
-const shortAdjectives = adjectives.filter((a) => a.length <= MAX_WORD_LENGTH)
-const shortColors = colors.filter((c) => c.length <= MAX_WORD_LENGTH)
-const shortAnimals = animals.filter((a) => a.length <= MAX_WORD_LENGTH)
-
-export function randomName() {
-  return uniqueNamesGenerator({
-    dictionaries: [shortAdjectives, shortColors, shortAnimals],
-    length: 3,
-    style: 'capital',
-    separator: ''
-  })
-}
+export const MAX_NAME_LENGTH = 21
 
 function getAiName(difficulty: Difficulty) {
   return `${t('game.ai')} (${t(`game-settings.difficulty.${difficulty}`)})`

--- a/apps/front/src/utils/playerIdentity.ts
+++ b/apps/front/src/utils/playerIdentity.ts
@@ -1,0 +1,28 @@
+import {
+  type PlayerCredentials,
+  playerCredentialsSchema
+} from '@knucklebones/common'
+import { createPlayer } from './api'
+
+const PLAYER_ID_KEY = 'playerId'
+const PLAYER_CREDENTIAL_KEY = 'playerCredential'
+
+export function getStoredPlayerCredentials(): PlayerCredentials | undefined {
+  const result = playerCredentialsSchema.safeParse({
+    playerId: localStorage.getItem(PLAYER_ID_KEY),
+    credential: localStorage.getItem(PLAYER_CREDENTIAL_KEY)
+  })
+  return result.success ? result.data : undefined
+}
+
+export async function ensurePlayerIdentity(): Promise<PlayerCredentials> {
+  const storedCredentials = getStoredPlayerCredentials()
+  if (storedCredentials !== undefined) {
+    return storedCredentials
+  }
+
+  const credentials = await createPlayer()
+  localStorage.setItem(PLAYER_ID_KEY, credentials.playerId)
+  localStorage.setItem(PLAYER_CREDENTIAL_KEY, credentials.credential)
+  return credentials
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,6 @@ importers:
       react-use-websocket:
         specifier: ^4.13.0
         version: 4.13.0
-      unique-names-generator:
-        specifier: ^4.7.1
-        version: 4.7.1
       uuid:
         specifier: ^14.0.1
         version: 14.0.1
@@ -2816,10 +2813,6 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
-  unique-names-generator@4.7.1:
-    resolution: {integrity: sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==}
-    engines: {node: '>=8'}
-
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
@@ -5424,8 +5417,6 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
-
-  unique-names-generator@4.7.1: {}
 
   unrs-resolver@1.12.2:
     dependencies:


### PR DESCRIPTION
## Summary

- create and persist a UUID player identity before rendering application routes
- migrate legacy name-based IDs and reuse valid credentials on later visits
- show localized loading and retry states when identity creation is unavailable
- remove the obsolete random-name generator dependency
