### PR TITLE
feat: authenticate player mutations

### DIFF
--- a/apps/front/src/components/GameContext/useGameSetup.ts
+++ b/apps/front/src/components/GameContext/useGameSetup.ts
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { useLocation } from 'react-router-dom'
 import useWebSocketImport, { ReadyState } from 'react-use-websocket'
 import {
+  AI_PLAYER_ID,
   compatibleGameStateMessageSchema,
   GameState,
   type IGameState,
@@ -111,7 +112,7 @@ export function useGameSetup() {
           // À déplacer côté serveur
           if (state?.playerType === 'ai') {
             await initGame(
-              { roomKey, playerId: 'beep-boop' },
+              { roomKey, playerId: AI_PLAYER_ID },
               {
                 playerType: 'ai',
                 difficulty: state?.difficulty,

--- a/apps/front/src/utils/api.ts
+++ b/apps/front/src/utils/api.ts
@@ -103,6 +103,9 @@ export async function deleteDisplayName({
 async function sendApiRequest(path: string, method: Method, body?: unknown) {
   const headers = {
     Accept: 'application/json',
+    ...(localStorage.getItem('playerCredential') !== null && {
+      Authorization: `Bearer ${localStorage.getItem('playerCredential')}`
+    }),
     ...(body !== undefined && { 'Content-Type': 'application/json' })
   }
 

--- a/apps/worker/src/utils/authentication.ts
+++ b/apps/worker/src/utils/authentication.ts
@@ -1,0 +1,59 @@
+import { AI_PLAYER_ID } from '@knucklebones/common'
+import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
+import { type BaseRequestWithProps } from '../types/itty'
+import { hashCredential } from './credentials'
+import { apiError } from './http'
+
+interface PlayerIdentityRow {
+  player_id: string
+}
+
+export async function authenticatePlayerMutation(
+  request: Request & BaseRequestWithProps,
+  cloudflareEnvironment: CloudflareEnvironment
+): Promise<Response | undefined> {
+  const credential = getBearerCredential(request.headers.get('Authorization'))
+
+  if (credential === undefined) {
+    return apiError({
+      status: 401,
+      code: 'PLAYER_CREDENTIAL_REQUIRED',
+      message: 'A valid player credential is required.',
+      requestId: request.requestId
+    })
+  }
+
+  const credentialHash = await hashCredential(credential)
+  const identity = await cloudflareEnvironment.PLAYERS_DB.prepare(
+    'SELECT player_id FROM players WHERE credential_hash = ?'
+  )
+    .bind(credentialHash)
+    .first<PlayerIdentityRow>()
+
+  if (identity === null) {
+    return apiError({
+      status: 401,
+      code: 'INVALID_PLAYER_CREDENTIAL',
+      message: 'The player credential is invalid.',
+      requestId: request.requestId
+    })
+  }
+
+  const isAiSetup =
+    request.playerId === AI_PLAYER_ID &&
+    new URL(request.url).pathname.endsWith(`/${AI_PLAYER_ID}/init`)
+
+  if (request.playerId !== identity.player_id && !isAiSetup) {
+    return apiError({
+      status: 403,
+      code: 'PLAYER_ID_MISMATCH',
+      message: 'The player credential does not match the requested player.',
+      requestId: request.requestId
+    })
+  }
+}
+
+function getBearerCredential(authorization: string | null): string | undefined {
+  const match = authorization?.match(/^Bearer ([0-9a-f]{64})$/)
+  return match?.[1]
+}

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -12,6 +12,7 @@ import {
 } from '../endpoints'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
 import { type RequestWithId } from '../types/itty'
+import { authenticatePlayerMutation } from '../utils/authentication'
 import {
   apiError,
   sanitizeRequestForSentry,
@@ -24,13 +25,15 @@ export { WebSocketDurableObject } from '../durable-objects/WebSocketDurableObjec
 const router = Router()
 
 const { preflight, corsify } = cors({
-  allowMethods: ['POST', 'DELETE']
+  allowMethods: ['POST', 'DELETE'],
+  allowHeaders: ['Authorization', 'Content-Type']
 })
 
 router
   .all('*', withDurables({ parse: true }), preflight, withParams)
 
   .post('/players', createPlayer)
+  .all('/:roomKey/:playerId/*', authenticatePlayerMutation)
   .post('/:roomKey/:playerId/init', init)
   .post('/:roomKey/:playerId/play/:column/:dice', play)
   .post('/:roomKey/:playerId/rematch', rematch)

--- a/packages/common/src/types/playerIdentity.ts
+++ b/packages/common/src/types/playerIdentity.ts
@@ -1,3 +1,5 @@
+export const AI_PLAYER_ID = 'beep-boop'
+
 export interface PlayerCredentials {
   playerId: string
   credential: string


### PR DESCRIPTION
## Summary

- require D1-backed bearer credentials for room mutations
- reject missing, invalid, cross-player, and unauthorized AI mutations with structured errors
- send stored player credentials from the frontend and allow the authorization header through CORS