### PR TITLE
feat: make game mutations idempotent

### DIFF
--- a/apps/front/src/utils/api.ts
+++ b/apps/front/src/utils/api.ts
@@ -80,7 +80,7 @@ export async function initGame(
 
   const path = `/${roomKey}/${playerId}/init${queryParamsString}`
 
-  await sendApiRequest(path, 'POST')
+  await sendMutationRequest(path, 'POST')
 }
 
 // Pas besoin de repréciser `boType` si il change pas de la partie en cours
@@ -98,7 +98,7 @@ export async function voteRematch(
   }
 
   const path = `/${roomKey}/${playerId}/rematch?${urlSearchParams.toString()}`
-  await sendApiRequest(path, 'POST')
+  await sendMutationRequest(path, 'POST')
 }
 
 interface PlayRequestParams {
@@ -110,7 +110,7 @@ export async function play(
   { column, dice }: PlayRequestParams
 ) {
   const path = `/${roomKey}/${playerId}/play/${column}/${dice}`
-  await sendApiRequest(path, 'POST')
+  await sendMutationRequest(path, 'POST')
 }
 interface UpdateDisplayNameRequestParams {
   displayName: string
@@ -120,7 +120,7 @@ export async function updateDisplayName(
   { displayName }: UpdateDisplayNameRequestParams
 ) {
   const path = `/${roomKey}/${playerId}/displayName/${displayName}`
-  await sendApiRequest(path, 'POST')
+  await sendMutationRequest(path, 'POST')
 }
 
 export async function deleteDisplayName({
@@ -128,39 +128,63 @@ export async function deleteDisplayName({
   roomKey
 }: IdentificationParams) {
   const path = `/${roomKey}/${playerId}/displayName`
-  await sendApiRequest(path, 'DELETE')
+  await sendMutationRequest(path, 'DELETE')
+}
+
+async function sendMutationRequest(path: string, method: 'POST' | 'DELETE') {
+  const mutationId = crypto.randomUUID()
+  return await sendApiRequest(path, method, undefined, undefined, mutationId)
 }
 
 async function sendApiRequest(
   path: string,
   method: Method,
   body?: unknown,
-  credential = localStorage.getItem('playerCredential')
+  credential = localStorage.getItem('playerCredential'),
+  mutationId?: string
 ) {
   const headers = {
     Accept: 'application/json',
     ...(credential !== null && {
       Authorization: `Bearer ${credential}`
     }),
+    ...(mutationId !== undefined && { 'Idempotency-Key': mutationId }),
     ...(body !== undefined && { 'Content-Type': 'application/json' })
   }
 
-  return await fetch(`${import.meta.env.VITE_WORKER_URL}${path}`, {
-    method,
-    headers,
-    ...(body !== undefined && { body: JSON.stringify(body) })
-  })
-    .then(async (resp) => {
-      if (!resp.ok) {
+  const attempts = mutationId === undefined ? 1 : 2
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    let response: Response
+
+    try {
+      response = await fetch(`${import.meta.env.VITE_WORKER_URL}${path}`, {
+        method,
+        headers,
+        ...(body !== undefined && { body: JSON.stringify(body) })
+      })
+    } catch (error) {
+      if (attempt === attempts - 1) {
         throw new Error(
-          `[${resp.status}:${resp.statusText}] There was an error while doing a network call. Please try again.`
+          'There was an error while doing a network call. Please try again.',
+          { cause: error }
         )
       }
-      return resp
-    })
-    .catch(() => {
+      continue
+    }
+
+    if (response.ok) {
+      return response
+    }
+
+    if (response.status < 500 || attempt === attempts - 1) {
       throw new Error(
-        'There was an error while doing a network call. Please try again.'
+        `[${response.status}:${response.statusText}] There was an error while doing a network call. Please try again.`
       )
-    })
+    }
+  }
+
+  throw new Error(
+    'There was an error while doing a network call. Please try again.'
+  )
 }

--- a/apps/worker/src/durable-objects/GameStateDurableObject.ts
+++ b/apps/worker/src/durable-objects/GameStateDurableObject.ts
@@ -15,6 +15,7 @@ import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
 import { type IttyDurableObjectNamespace } from '../types/itty'
 
 interface InitializeGameCommand {
+  mutationId: string
   playerId: string
   displayName?: string
   difficulty?: Difficulty
@@ -36,11 +37,27 @@ export type PlayGameResult =
   | { status: 'rejected'; reason: PlayRejectionReason }
   | { status: 'updated'; gameState: IGameState }
 
+export type IdempotentMutationResult<T> =
+  | { idempotencyStatus: 'applied' | 'replayed'; value: T }
+  | { idempotencyStatus: 'conflict' }
+
+interface ProcessedMutation {
+  fingerprint: string
+  processedAt: number
+  value: unknown
+}
+
+type ProcessedMutations = Record<string, ProcessedMutation>
+
+const PROCESSED_MUTATION_TTL_MS = 15 * 60 * 1000
+const MAX_PROCESSED_MUTATIONS = 200
+
 export class GameStateDurableObject extends createDurable({
   autoPersist: true
 }) {
   lobby: ILobby
   gameState?: IGameState
+  processedMutations: ProcessedMutations
 
   constructor(
     state: DurableObjectState,
@@ -48,14 +65,31 @@ export class GameStateDurableObject extends createDurable({
   ) {
     super(state, cloudflareEnvironment)
     this.lobby = new Lobby().toJson()
+    this.processedMutations = {}
   }
 
   initializeGame({
+    mutationId,
     playerId,
     displayName,
     difficulty,
     boType
-  }: InitializeGameCommand): InitializeGameResult {
+  }: InitializeGameCommand): IdempotentMutationResult<InitializeGameResult> {
+    return this.runIdempotently(
+      mutationId,
+      'initialize-game',
+      { playerId, displayName, difficulty, boType },
+      () =>
+        this.applyInitializeGame({ playerId, displayName, difficulty, boType })
+    )
+  }
+
+  private applyInitializeGame({
+    playerId,
+    displayName,
+    difficulty,
+    boType
+  }: Omit<InitializeGameCommand, 'mutationId'>): InitializeGameResult {
     if (this.gameState !== undefined) {
       const gameState = GameState.fromJson(this.gameState)
       let serializedGameState = gameState.toJson()
@@ -87,7 +121,16 @@ export class GameStateDurableObject extends createDurable({
     return { status: 'created', gameState }
   }
 
-  play(play: Play): PlayGameResult {
+  play(
+    mutationId: string,
+    play: Play
+  ): IdempotentMutationResult<PlayGameResult> {
+    return this.runIdempotently(mutationId, 'play', play, () =>
+      this.applyPlay(play)
+    )
+  }
+
+  private applyPlay(play: Play): PlayGameResult {
     const gameState = this.getInitializedGameState()
     const rejectionReason = gameState.getPlayRejectionReason(play)
 
@@ -100,6 +143,19 @@ export class GameStateDurableObject extends createDurable({
   }
 
   rematch(
+    mutationId: string,
+    playerId: string,
+    gameSettings?: Omit<GameSettings, 'playerType'>
+  ): IdempotentMutationResult<RematchGameResult> {
+    return this.runIdempotently(
+      mutationId,
+      'rematch',
+      { playerId, gameSettings },
+      () => this.applyRematch(playerId, gameSettings)
+    )
+  }
+
+  private applyRematch(
     playerId: string,
     gameSettings?: Omit<GameSettings, 'playerType'>
   ): RematchGameResult {
@@ -144,6 +200,19 @@ export class GameStateDurableObject extends createDurable({
   }
 
   updateDisplayName(
+    mutationId: string,
+    playerId: string,
+    displayName?: string
+  ): IdempotentMutationResult<UpdateDisplayNameResult> {
+    return this.runIdempotently(
+      mutationId,
+      'update-display-name',
+      { playerId, displayName },
+      () => this.applyDisplayNameUpdate(playerId, displayName)
+    )
+  }
+
+  private applyDisplayNameUpdate(
     playerId: string,
     displayName?: string
   ): UpdateDisplayNameResult {
@@ -175,6 +244,44 @@ export class GameStateDurableObject extends createDurable({
     }
 
     return GameState.fromJson(this.gameState)
+  }
+
+  private runIdempotently<T>(
+    mutationId: string,
+    operation: string,
+    payload: unknown,
+    mutation: () => T
+  ): IdempotentMutationResult<T> {
+    const fingerprint = JSON.stringify({ operation, payload })
+    const processedMutation = this.processedMutations[mutationId]
+
+    if (processedMutation !== undefined) {
+      if (processedMutation.fingerprint !== fingerprint) {
+        return { idempotencyStatus: 'conflict' }
+      }
+
+      return {
+        idempotencyStatus: 'replayed',
+        value: processedMutation.value as T
+      }
+    }
+
+    const value = mutation()
+    const processedAt = Date.now()
+    const activeMutations = Object.entries(this.processedMutations)
+      .filter(
+        ([, processed]) =>
+          processed.processedAt > processedAt - PROCESSED_MUTATION_TTL_MS
+      )
+      .sort(([, left], [, right]) => right.processedAt - left.processedAt)
+      .slice(0, MAX_PROCESSED_MUTATIONS - 1)
+
+    this.processedMutations = Object.fromEntries([
+      [mutationId, { fingerprint, processedAt, value }],
+      ...activeMutations
+    ])
+
+    return { idempotencyStatus: 'applied', value }
   }
 }
 

--- a/apps/worker/src/endpoints/deleteDisplayName.ts
+++ b/apps/worker/src/endpoints/deleteDisplayName.ts
@@ -1,22 +1,30 @@
 import { status } from 'itty-router'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type BaseRequestWithProps } from '../types/itty'
+import { type MutationRequestWithProps } from '../types/itty'
 import {
   broadcastGameState,
   getGameStateDurableObject
 } from '../utils/endpoints'
 import { apiError } from '../utils/http'
+import { idempotencyConflict } from '../utils/idempotency'
 
 export async function deleteDisplayName(
-  request: BaseRequestWithProps,
+  request: MutationRequestWithProps,
   cloudflareEnvironment: CloudflareEnvironment
 ) {
   const result = await getGameStateDurableObject(request).updateDisplayName(
+    request.mutationId,
     request.playerId,
     undefined
   )
 
-  if (result.status === 'unknown-player') {
+  if (result.idempotencyStatus === 'conflict') {
+    return idempotencyConflict(request.requestId)
+  }
+
+  const mutation = result.value
+
+  if (mutation.status === 'unknown-player') {
     return apiError({
       status: 400,
       code: 'UNEXPECTED_PLAYER_ID',
@@ -25,7 +33,7 @@ export async function deleteDisplayName(
     })
   }
 
-  await broadcastGameState(result.gameState, request, cloudflareEnvironment)
+  await broadcastGameState(mutation.gameState, request, cloudflareEnvironment)
 
   return status(200)
 }

--- a/apps/worker/src/endpoints/displayName.ts
+++ b/apps/worker/src/endpoints/displayName.ts
@@ -1,14 +1,15 @@
 import { status } from 'itty-router'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type BaseRequestWithProps } from '../types/itty'
+import { type MutationRequestWithProps } from '../types/itty'
 import {
   broadcastGameState,
   getGameStateDurableObject
 } from '../utils/endpoints'
 import { apiError } from '../utils/http'
+import { idempotencyConflict } from '../utils/idempotency'
 
-interface DisplayNameRequest extends BaseRequestWithProps {
-  displayName: string
+interface DisplayNameRequest extends MutationRequestWithProps {
+  displayName?: string
 }
 
 export async function displayName(
@@ -16,11 +17,18 @@ export async function displayName(
   cloudflareEnvironment: CloudflareEnvironment
 ) {
   const result = await getGameStateDurableObject(request).updateDisplayName(
+    request.mutationId,
     request.playerId,
     request.displayName
   )
 
-  if (result.status === 'unknown-player') {
+  if (result.idempotencyStatus === 'conflict') {
+    return idempotencyConflict(request.requestId)
+  }
+
+  const mutation = result.value
+
+  if (mutation.status === 'unknown-player') {
     return apiError({
       status: 400,
       code: 'UNEXPECTED_PLAYER_ID',
@@ -29,7 +37,7 @@ export async function displayName(
     })
   }
 
-  await broadcastGameState(result.gameState, request, cloudflareEnvironment)
+  await broadcastGameState(mutation.gameState, request, cloudflareEnvironment)
 
   return status(200)
 }

--- a/apps/worker/src/endpoints/init.ts
+++ b/apps/worker/src/endpoints/init.ts
@@ -1,14 +1,15 @@
 import { status } from 'itty-router'
 import { GameState, type Difficulty, type BoType } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type BaseRequestWithProps } from '../types/itty'
+import { type MutationRequestWithProps } from '../types/itty'
 import { makeAiPlay } from '../utils/ai'
 import {
   broadcastGameState,
   getGameStateDurableObject
 } from '../utils/endpoints'
+import { idempotencyConflict } from '../utils/idempotency'
 
-export interface InitRequest extends BaseRequestWithProps {
+export interface InitRequest extends MutationRequestWithProps {
   query?: { displayName?: string; difficulty?: Difficulty; boType?: BoType }
 }
 
@@ -18,18 +19,25 @@ export async function init(
   context: ExecutionContext
 ) {
   const result = await getGameStateDurableObject(request).initializeGame({
+    mutationId: request.mutationId,
     playerId: request.playerId,
     displayName: request.query?.displayName,
     difficulty: request.query?.difficulty,
     boType: request.query?.boType
   })
 
-  if (result.status !== 'waiting') {
-    const gameState = GameState.fromJson(result.gameState)
-    await broadcastGameState(result.gameState, request, cloudflareEnvironment)
+  if (result.idempotencyStatus === 'conflict') {
+    return idempotencyConflict(request.requestId)
+  }
+
+  const mutation = result.value
+
+  if (mutation.status !== 'waiting') {
+    const gameState = GameState.fromJson(mutation.gameState)
+    await broadcastGameState(mutation.gameState, request, cloudflareEnvironment)
 
     if (
-      result.status === 'created' &&
+      mutation.status === 'created' &&
       gameState.playerTwo.isAi() &&
       gameState.nextPlayer.equals(gameState.playerTwo)
     ) {

--- a/apps/worker/src/endpoints/play.ts
+++ b/apps/worker/src/endpoints/play.ts
@@ -1,17 +1,18 @@
 import { status } from 'itty-router'
 import { GameState, type PlayRejectionReason } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type BaseRequestWithProps } from '../types/itty'
+import { type MutationRequestWithProps } from '../types/itty'
 import { makeAiPlay } from '../utils/ai'
 import {
   broadcastGameState,
   getGameStateDurableObject
 } from '../utils/endpoints'
 import { apiError } from '../utils/http'
+import { idempotencyConflict } from '../utils/idempotency'
 
-interface PlayRequest extends BaseRequestWithProps {
-  dice: number
-  column: number
+interface PlayRequest extends MutationRequestWithProps {
+  dice?: number
+  column?: number
 }
 
 export async function play(
@@ -25,14 +26,23 @@ export async function play(
     author: request.playerId
   }
 
-  const result = await getGameStateDurableObject(request).play(play)
+  const result = await getGameStateDurableObject(request).play(
+    request.mutationId,
+    play
+  )
 
-  if (result.status === 'rejected') {
-    return playError(result.reason, request.requestId)
+  if (result.idempotencyStatus === 'conflict') {
+    return idempotencyConflict(request.requestId)
   }
 
-  const gameState = GameState.fromJson(result.gameState)
-  await broadcastGameState(result.gameState, request, cloudflareEnvironment)
+  const mutation = result.value
+
+  if (mutation.status === 'rejected') {
+    return playError(mutation.reason, request.requestId)
+  }
+
+  const gameState = GameState.fromJson(mutation.gameState)
+  await broadcastGameState(mutation.gameState, request, cloudflareEnvironment)
 
   if (
     gameState.outcome === 'ongoing' &&

--- a/apps/worker/src/endpoints/rematch.ts
+++ b/apps/worker/src/endpoints/rematch.ts
@@ -1,15 +1,16 @@
 import { status } from 'itty-router'
 import { type GameSettings, GameState } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type BaseRequestWithProps } from '../types/itty'
+import { type MutationRequestWithProps } from '../types/itty'
 import { makeAiPlay } from '../utils/ai'
 import {
   broadcastGameState,
   getGameStateDurableObject
 } from '../utils/endpoints'
 import { apiError } from '../utils/http'
+import { idempotencyConflict } from '../utils/idempotency'
 
-export interface RematchRequest extends BaseRequestWithProps {
+export interface RematchRequest extends MutationRequestWithProps {
   query?: Omit<GameSettings, 'playerType'>
 }
 
@@ -19,11 +20,18 @@ export async function rematch(
   context: ExecutionContext
 ) {
   const result = await getGameStateDurableObject(request).rematch(
+    request.mutationId,
     request.playerId,
     request.query
   )
 
-  if (result.status === 'game-ongoing') {
+  if (result.idempotencyStatus === 'conflict') {
+    return idempotencyConflict(request.requestId)
+  }
+
+  const mutation = result.value
+
+  if (mutation.status === 'game-ongoing') {
     return apiError({
       status: 409,
       code: 'GAME_STILL_ONGOING',
@@ -32,9 +40,9 @@ export async function rematch(
     })
   }
 
-  if (result.status === 'updated') {
-    const gameState = GameState.fromJson(result.gameState)
-    await broadcastGameState(result.gameState, request, cloudflareEnvironment)
+  if (mutation.status === 'updated') {
+    const gameState = GameState.fromJson(mutation.gameState)
+    await broadcastGameState(mutation.gameState, request, cloudflareEnvironment)
 
     if (
       gameState.outcome === 'ongoing' &&

--- a/apps/worker/src/types/itty.ts
+++ b/apps/worker/src/types/itty.ts
@@ -14,8 +14,15 @@ export interface RequestWithId {
   requestId: string
 }
 
+export interface RequestWithMutationId {
+  mutationId: string
+}
+
 export interface BaseRequestWithProps
   extends GameStateDurableObjectProps, RequestWithId {
   roomKey: string
   playerId: string
 }
+
+export interface MutationRequestWithProps
+  extends BaseRequestWithProps, RequestWithMutationId {}

--- a/apps/worker/src/utils/ai.ts
+++ b/apps/worker/src/utils/ai.ts
@@ -6,11 +6,11 @@ import {
 import { Ai } from '../classes/Ai'
 import { play } from '../endpoints'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type BaseRequestWithProps } from '../types/itty'
+import { type MutationRequestWithProps } from '../types/itty'
 
 export function makeAiPlay(
   gameState: GameState,
-  request: BaseRequestWithProps,
+  request: MutationRequestWithProps,
   cloudflareEnvironment: CloudflareEnvironment,
   context: ExecutionContext
 ) {
@@ -37,6 +37,7 @@ export function makeAiPlay(
         roomKey: request.roomKey,
         playerId: gameState.playerTwo.id,
         requestId: request.requestId,
+        mutationId: `${request.mutationId}:ai`,
         GAME_STATE_DURABLE_OBJECT: request.GAME_STATE_DURABLE_OBJECT
       },
       cloudflareEnvironment,

--- a/apps/worker/src/utils/http.ts
+++ b/apps/worker/src/utils/http.ts
@@ -58,7 +58,13 @@ export function sanitizeRequestForSentry(
   url.search = ''
 
   const headers = new Headers({ 'X-Request-Id': requestId })
-  const safeHeaderNames = ['Accept', 'Content-Type', 'User-Agent', 'CF-Ray']
+  const safeHeaderNames = [
+    'Accept',
+    'Content-Type',
+    'User-Agent',
+    'CF-Ray',
+    'Idempotency-Key'
+  ]
 
   safeHeaderNames.forEach((headerName) => {
     const value = request.headers.get(headerName)

--- a/apps/worker/src/utils/idempotency.ts
+++ b/apps/worker/src/utils/idempotency.ts
@@ -1,0 +1,41 @@
+import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
+import { type MutationRequestWithProps } from '../types/itty'
+import { apiError } from './http'
+
+const IDEMPOTENCY_KEY_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+type MutationMiddleware = (
+  request: Request & MutationRequestWithProps,
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+) => Response | undefined
+
+export const withMutationId: MutationMiddleware = (request) => {
+  const mutationId = request.headers.get('Idempotency-Key')
+
+  if (mutationId === null) {
+    request.mutationId = crypto.randomUUID()
+    return
+  }
+
+  if (!IDEMPOTENCY_KEY_PATTERN.test(mutationId)) {
+    return apiError({
+      status: 400,
+      code: 'INVALID_IDEMPOTENCY_KEY',
+      message: 'The Idempotency-Key header must be a valid UUID.',
+      requestId: request.requestId
+    })
+  }
+
+  request.mutationId = mutationId
+}
+
+export function idempotencyConflict(requestId: string): Response {
+  return apiError({
+    status: 409,
+    code: 'IDEMPOTENCY_KEY_REUSED',
+    message: 'The idempotency key was already used for another mutation.',
+    requestId
+  })
+}

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -20,6 +20,7 @@ import {
   sanitizeRequestForSentry,
   withRequestId
 } from '../utils/http'
+import { withMutationId } from '../utils/idempotency'
 
 export { GameStateDurableObject } from '../durable-objects/GameStateDurableObject'
 export { WebSocketDurableObject } from '../durable-objects/WebSocketDurableObject'
@@ -28,7 +29,7 @@ const router = Router()
 
 const { preflight, corsify } = cors({
   allowMethods: ['POST', 'DELETE'],
-  allowHeaders: ['Authorization', 'Content-Type']
+  allowHeaders: ['Authorization', 'Content-Type', 'Idempotency-Key']
 })
 
 router
@@ -39,12 +40,16 @@ router
   .post('/players/:playerId/verify', verifyPlayer)
   .all('/:roomKey/:playerId/*', authenticatePlayerRequest)
   .post('/:roomKey/:playerId/websocket-ticket', createWebSocketTicket)
-  .post('/:roomKey/:playerId/init', init)
-  .post('/:roomKey/:playerId/play/:column/:dice', play)
-  .post('/:roomKey/:playerId/rematch', rematch)
-  .post('/:roomKey/:playerId/displayName/:displayName', displayName)
+  .post('/:roomKey/:playerId/init', withMutationId, init)
+  .post('/:roomKey/:playerId/play/:column/:dice', withMutationId, play)
+  .post('/:roomKey/:playerId/rematch', withMutationId, rematch)
+  .post(
+    '/:roomKey/:playerId/displayName/:displayName',
+    withMutationId,
+    displayName
+  )
 
-  .delete('/:roomKey/:playerId/displayName', deleteDisplayName)
+  .delete('/:roomKey/:playerId/displayName', withMutationId, deleteDisplayName)
 
   .all('*', (request: RequestWithId) =>
     apiError({


### PR DESCRIPTION
## Summary

- persist bounded idempotency results with each authoritative room and reject conflicting key reuse
- safely replay moves, rematches, initialization, and display-name changes without advancing state twice
- retry transient frontend failures once with the same key while preserving compatibility with already-open clients