### PR TITLE
feat(game): make play commands authoritative

### DIFF
--- a/apps/front/src/components/GameContext/useGameSetup.ts
+++ b/apps/front/src/components/GameContext/useGameSetup.ts
@@ -149,7 +149,7 @@ export function useGameSetup() {
 
       setGameState(mutatedGameState)
 
-      await play({ roomKey, playerId }, { column, dice }).catch((error) => {
+      await play({ roomKey, playerId }, { column }).catch((error) => {
         setErrorMessage(error.message)
         setGameState(previousGameState)
         setIsLoading(false)

--- a/apps/front/src/utils/api.test.ts
+++ b/apps/front/src/utils/api.test.ts
@@ -20,7 +20,7 @@ describe('mutation requests', () => {
       .mockRejectedValueOnce(new TypeError('offline'))
       .mockResolvedValueOnce(new Response(null, { status: 200 }))
 
-    await play(room, { column: 1, dice: 4 })
+    await play(room, { column: 1 })
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
     const firstHeaders = fetchMock.mock.calls[0][1]?.headers as Record<
@@ -37,6 +37,10 @@ describe('mutation requests', () => {
     expect(secondHeaders['Idempotency-Key']).toBe(
       firstHeaders['Idempotency-Key']
     )
+    expect(fetchMock.mock.calls[0][0]).toContain(
+      `/v1/rooms/${room.roomKey}/play`
+    )
+    expect(fetchMock.mock.calls[0][1]?.body).toBe('{"column":1}')
   })
 
   it('does not retry a client error', async () => {
@@ -44,9 +48,7 @@ describe('mutation requests', () => {
       new Response(null, { status: 409, statusText: 'Conflict' })
     )
 
-    await expect(play(room, { column: 1, dice: 4 })).rejects.toThrow(
-      '[409:Conflict]'
-    )
+    await expect(play(room, { column: 1 })).rejects.toThrow('[409:Conflict]')
     expect(fetchMock).toHaveBeenCalledOnce()
   })
 
@@ -65,7 +67,7 @@ describe('mutation requests', () => {
       )
     )
 
-    await expect(play(room, { column: 1, dice: 4 })).rejects.toThrow(
+    await expect(play(room, { column: 1 })).rejects.toThrow(
       '[NOT_PLAYER_TURN: It is not your turn.]'
     )
   })
@@ -77,7 +79,7 @@ describe('mutation requests', () => {
       )
       .mockResolvedValueOnce(new Response(null, { status: 200 }))
 
-    await play(room, { column: 1, dice: 4 })
+    await play(room, { column: 1 })
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
     const firstHeaders = fetchMock.mock.calls[0][1]?.headers as Record<
@@ -96,7 +98,7 @@ describe('mutation requests', () => {
   it('reports an error after the retry is exhausted', async () => {
     fetchMock.mockRejectedValue(new TypeError('offline'))
 
-    await expect(play(room, { column: 1, dice: 4 })).rejects.toThrow(
+    await expect(play(room, { column: 1 })).rejects.toThrow(
       'There was an error while doing a network call.'
     )
     expect(fetchMock).toHaveBeenCalledTimes(2)

--- a/apps/front/src/utils/api.ts
+++ b/apps/front/src/utils/api.ts
@@ -103,15 +103,14 @@ export async function voteRematch(
 }
 
 interface PlayRequestParams {
-  dice: number
   column: number
 }
 export async function play(
-  { playerId, roomKey }: IdentificationParams,
-  { column, dice }: PlayRequestParams
+  { roomKey }: IdentificationParams,
+  { column }: PlayRequestParams
 ) {
-  const path = `/${roomKey}/${playerId}/play/${column}/${dice}`
-  await sendMutationRequest(path, 'POST')
+  const path = `/v1/rooms/${roomKey}/play`
+  await sendMutationRequest(path, 'POST', { column })
 }
 interface UpdateDisplayNameRequestParams {
   displayName: string
@@ -132,9 +131,13 @@ export async function deleteDisplayName({
   await sendMutationRequest(path, 'DELETE')
 }
 
-async function sendMutationRequest(path: string, method: 'POST' | 'DELETE') {
+async function sendMutationRequest(
+  path: string,
+  method: 'POST' | 'DELETE',
+  body?: unknown
+) {
   const mutationId = crypto.randomUUID()
-  return await sendApiRequest(path, method, undefined, undefined, mutationId)
+  return await sendApiRequest(path, method, body, undefined, mutationId)
 }
 
 async function sendApiRequest(

--- a/apps/worker/src/durable-objects/GameStateDurableObject.ts
+++ b/apps/worker/src/durable-objects/GameStateDurableObject.ts
@@ -13,7 +13,7 @@ import {
   Lobby,
   lobbySchema,
   Player,
-  type Play,
+  type PlayGameCommand,
   type PlayGameResult,
   playGameCommandSchema,
   playGameResultSchema,
@@ -26,6 +26,7 @@ import {
 } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
 import { type IttyDurableObjectNamespace } from '../types/itty'
+import { applyPlayCommand } from '../utils/authoritativeGame'
 
 interface ProcessedMutation {
   fingerprint: string
@@ -128,31 +129,32 @@ export class GameStateDurableObject extends createDurable({
     return { status: 'created', gameState }
   }
 
-  play(
-    mutationId: string,
-    play: Play
-  ): IdempotentMutationResult<PlayGameResult> {
-    const command = playGameCommandSchema.parse({ mutationId, play })
+  play(command: PlayGameCommand): IdempotentMutationResult<PlayGameResult> {
+    const parsedCommand = playGameCommandSchema.parse(command)
 
     return this.runIdempotently(
-      command.mutationId,
+      parsedCommand.mutationId,
       'play',
-      command.play,
+      {
+        actorId: parsedCommand.actorId,
+        column: parsedCommand.column,
+        expectedRevision: parsedCommand.expectedRevision
+      },
       playGameResultSchema,
-      () => this.applyPlay(command.play)
+      () => this.applyPlayIntent(parsedCommand)
     )
   }
 
-  private applyPlay(play: Play): PlayGameResult {
-    const gameState = this.getInitializedGameState()
-    const rejectionReason = gameState.getPlayRejectionReason(play)
-
-    if (rejectionReason !== undefined) {
-      return { status: 'rejected', reason: rejectionReason }
+  private applyPlayIntent(command: PlayGameCommand): PlayGameResult {
+    const result = applyPlayCommand(this.gameState, command)
+    if (result.status === 'rejected') {
+      return result
     }
 
-    gameState.applyPlay(play)
-    return { status: 'updated', gameState: this.commitGameState(gameState) }
+    return {
+      status: 'updated',
+      gameState: this.commitGameState(result.gameState)
+    }
   }
 
   rematch(

--- a/apps/worker/src/endpoints/deleteDisplayName.ts
+++ b/apps/worker/src/endpoints/deleteDisplayName.ts
@@ -1,7 +1,11 @@
 import { status } from 'itty-router'
-import { idempotentUpdateDisplayNameResultSchema } from '@knucklebones/common'
+import {
+  GameState,
+  idempotentUpdateDisplayNameResultSchema
+} from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
 import { type MutationRequestWithProps } from '../types/itty'
+import { makeAiPlay } from '../utils/ai'
 import {
   broadcastGameState,
   getGameStateDurableObject
@@ -11,7 +15,8 @@ import { idempotencyConflict } from '../utils/idempotency'
 
 export async function deleteDisplayName(
   request: MutationRequestWithProps,
-  cloudflareEnvironment: CloudflareEnvironment
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
 ) {
   const result = idempotentUpdateDisplayNameResultSchema.parse(
     await getGameStateDurableObject(request).updateDisplayName(
@@ -37,6 +42,15 @@ export async function deleteDisplayName(
   }
 
   await broadcastGameState(mutation.gameState, request, cloudflareEnvironment)
+
+  const gameState = GameState.fromJson(mutation.gameState)
+  if (
+    gameState.outcome === 'ongoing' &&
+    gameState.playerTwo.isAi() &&
+    gameState.nextPlayer.equals(gameState.playerTwo)
+  ) {
+    makeAiPlay(gameState, request, cloudflareEnvironment, context)
+  }
 
   return status(200)
 }

--- a/apps/worker/src/endpoints/displayName.ts
+++ b/apps/worker/src/endpoints/displayName.ts
@@ -1,10 +1,12 @@
 import { status } from 'itty-router'
 import {
   displayNameRouteParamsSchema,
+  GameState,
   idempotentUpdateDisplayNameResultSchema
 } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
 import { type MutationRequestWithProps } from '../types/itty'
+import { makeAiPlay } from '../utils/ai'
 import {
   broadcastGameState,
   getGameStateDurableObject
@@ -19,7 +21,8 @@ interface DisplayNameRequest extends MutationRequestWithProps {
 
 export async function displayName(
   request: DisplayNameRequest,
-  cloudflareEnvironment: CloudflareEnvironment
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
 ) {
   const params = displayNameRouteParamsSchema.safeParse({
     roomKey: request.roomKey,
@@ -54,6 +57,15 @@ export async function displayName(
   }
 
   await broadcastGameState(mutation.gameState, request, cloudflareEnvironment)
+
+  const gameState = GameState.fromJson(mutation.gameState)
+  if (
+    gameState.outcome === 'ongoing' &&
+    gameState.playerTwo.isAi() &&
+    gameState.nextPlayer.equals(gameState.playerTwo)
+  ) {
+    makeAiPlay(gameState, request, cloudflareEnvironment, context)
+  }
 
   return status(200)
 }

--- a/apps/worker/src/endpoints/init.ts
+++ b/apps/worker/src/endpoints/init.ts
@@ -69,7 +69,6 @@ export async function init(
     await broadcastGameState(mutation.gameState, request, cloudflareEnvironment)
 
     if (
-      mutation.status === 'created' &&
       gameState.playerTwo.isAi() &&
       gameState.nextPlayer.equals(gameState.playerTwo)
     ) {

--- a/apps/worker/src/endpoints/play.ts
+++ b/apps/worker/src/endpoints/play.ts
@@ -1,28 +1,29 @@
 import { status } from 'itty-router'
 import {
   GameState,
-  idempotentPlayGameResultSchema,
+  playIntentSchema,
   playRouteParamsSchema,
-  type PlayRejectionReason
+  type PlayIntentRejectionReason
 } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type MutationRequestWithProps } from '../types/itty'
-import { makeAiPlay } from '../utils/ai'
 import {
-  broadcastGameState,
-  getGameStateDurableObject
-} from '../utils/endpoints'
+  type AuthenticatedMutationRoomRequestWithProps,
+  type MutationRequestWithProps
+} from '../types/itty'
+import { makeAiPlay } from '../utils/ai'
+import { broadcastGameState } from '../utils/endpoints'
 import { apiError } from '../utils/http'
 import { idempotencyConflict } from '../utils/idempotency'
+import { applyAuthoritativePlay } from '../utils/play'
 import { invalidRouteParameters } from '../utils/validation'
 
-interface PlayRequest extends MutationRequestWithProps {
-  dice?: number
-  column?: number
+interface LegacyPlayRequest extends MutationRequestWithProps {
+  dice?: string
+  column?: string
 }
 
 export async function play(
-  request: PlayRequest,
+  request: LegacyPlayRequest,
   cloudflareEnvironment: CloudflareEnvironment,
   context: ExecutionContext
 ) {
@@ -36,22 +37,55 @@ export async function play(
     return invalidRouteParameters(request.requestId)
   }
 
-  const play = {
-    dice: Number(params.data.dice),
-    column: Number(params.data.column),
-    author: request.playerId
+  return await executePlayIntent(
+    request,
+    request.principal.playerId,
+    Number(params.data.column),
+    cloudflareEnvironment,
+    context
+  )
+}
+
+export async function playIntent(
+  request: Request & AuthenticatedMutationRoomRequestWithProps,
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+) {
+  const body = playIntentSchema.safeParse(
+    await request.json().catch(() => undefined)
+  )
+  if (!body.success) {
+    return apiError({
+      status: 400,
+      code: 'INVALID_PLAY_INTENT',
+      message: 'The play intent must contain a column between 0 and 2.',
+      requestId: request.requestId
+    })
   }
 
-  const result = idempotentPlayGameResultSchema.parse(
-    await getGameStateDurableObject(request).play(request.mutationId, play)
+  return await executePlayIntent(
+    request,
+    request.principal.playerId,
+    body.data.column,
+    cloudflareEnvironment,
+    context
   )
+}
+
+async function executePlayIntent(
+  request: AuthenticatedMutationRoomRequestWithProps,
+  actorId: string,
+  column: number,
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+) {
+  const result = await applyAuthoritativePlay(request, actorId, column)
 
   if (result.idempotencyStatus === 'conflict') {
     return idempotencyConflict(request.requestId)
   }
 
   const mutation = result.value
-
   if (mutation.status === 'rejected') {
     return playError(mutation.reason, request.requestId)
   }
@@ -70,34 +104,37 @@ export async function play(
   return status(200)
 }
 
-function playError(reason: PlayRejectionReason, requestId: string): Response {
+function playError(
+  reason: PlayIntentRejectionReason,
+  requestId: string
+): Response {
   switch (reason) {
+    case 'game-not-initialized':
+      return apiError({
+        status: 409,
+        code: 'GAME_NOT_INITIALIZED',
+        message: 'The game has not started yet.',
+        requestId
+      })
     case 'game-ended':
       return apiError({
         status: 409,
-        code: 'GAME_ENDED',
+        code: 'GAME_ALREADY_FINISHED',
         message: 'The game has already ended.',
         requestId
       })
     case 'unknown-player':
       return apiError({
         status: 403,
-        code: 'PLAYER_NOT_IN_GAME',
+        code: 'NOT_A_PLAYER',
         message: 'Only a player in this game can make a move.',
         requestId
       })
     case 'not-player-turn':
       return apiError({
         status: 409,
-        code: 'NOT_PLAYER_TURN',
+        code: 'NOT_YOUR_TURN',
         message: "It is not this player's turn.",
-        requestId
-      })
-    case 'unexpected-die':
-      return apiError({
-        status: 409,
-        code: 'DIE_MISMATCH',
-        message: 'The submitted die does not match the current turn.',
         requestId
       })
     case 'invalid-column':
@@ -112,6 +149,20 @@ function playError(reason: PlayRejectionReason, requestId: string): Response {
         status: 409,
         code: 'COLUMN_FULL',
         message: 'The selected column is already full.',
+        requestId
+      })
+    case 'invalid-game-state':
+      return apiError({
+        status: 409,
+        code: 'INVALID_GAME_STATE',
+        message: 'The authoritative game state is invalid.',
+        requestId
+      })
+    case 'stale-revision':
+      return apiError({
+        status: 409,
+        code: 'STALE_REVISION',
+        message: 'The game state changed before the move was applied.',
         requestId
       })
   }

--- a/apps/worker/src/types/itty.ts
+++ b/apps/worker/src/types/itty.ts
@@ -1,3 +1,4 @@
+import { type AuthenticatedPrincipal } from '@knucklebones/common'
 import { type GameStateDurableObjectProps } from '../durable-objects/GameStateDurableObject'
 
 export type PromisifyPublicFunctions<T> = {
@@ -18,9 +19,22 @@ export interface RequestWithMutationId {
   mutationId: string
 }
 
-export interface BaseRequestWithProps
+export interface AuthenticatedRequestWithProps extends RequestWithId {
+  principal: AuthenticatedPrincipal
+}
+
+export interface DurableRoomRequestWithProps
   extends GameStateDurableObjectProps, RequestWithId {
   roomKey: string
+}
+
+export interface AuthenticatedRoomRequestWithProps
+  extends DurableRoomRequestWithProps, AuthenticatedRequestWithProps {}
+
+export interface AuthenticatedMutationRoomRequestWithProps
+  extends AuthenticatedRoomRequestWithProps, RequestWithMutationId {}
+
+export interface BaseRequestWithProps extends AuthenticatedRoomRequestWithProps {
   playerId: string
 }
 

--- a/apps/worker/src/utils/ai.ts
+++ b/apps/worker/src/utils/ai.ts
@@ -4,13 +4,17 @@ import {
   sleep
 } from '@knucklebones/common'
 import { Ai } from '../classes/Ai'
-import { play } from '../endpoints'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type MutationRequestWithProps } from '../types/itty'
+import {
+  type DurableRoomRequestWithProps,
+  type RequestWithMutationId
+} from '../types/itty'
+import { broadcastGameState } from './endpoints'
+import { applyAuthoritativePlay, getAppliedPlayResult } from './play'
 
 export function makeAiPlay(
   gameState: GameState,
-  request: MutationRequestWithProps,
+  request: DurableRoomRequestWithProps & RequestWithMutationId,
   cloudflareEnvironment: CloudflareEnvironment,
   context: ExecutionContext
 ) {
@@ -30,19 +34,27 @@ export function makeAiPlay(
         : [500, 1000]
     await sleep(getRandomIntInclusive(min, max))
 
-    await play(
-      {
-        dice: gameState.playerTwo.dice!,
-        column: nextMove.column,
-        roomKey: request.roomKey,
-        playerId: gameState.playerTwo.id,
-        requestId: request.requestId,
-        mutationId: `${request.mutationId}:ai`,
-        GAME_STATE_DURABLE_OBJECT: request.GAME_STATE_DURABLE_OBJECT
-      },
-      cloudflareEnvironment,
-      context
+    const aiRequest = {
+      GAME_STATE_DURABLE_OBJECT: request.GAME_STATE_DURABLE_OBJECT,
+      roomKey: request.roomKey,
+      requestId: request.requestId,
+      mutationId: crypto.randomUUID()
+    }
+    const result = await applyAuthoritativePlay(
+      aiRequest,
+      gameState.playerTwo.id,
+      nextMove.column,
+      gameState.revision
     )
+    const mutation = getAppliedPlayResult(result)
+
+    if (mutation?.status === 'updated') {
+      await broadcastGameState(
+        mutation.gameState,
+        request,
+        cloudflareEnvironment
+      )
+    }
   }
 
   context.waitUntil(aiPlay())

--- a/apps/worker/src/utils/authentication.ts
+++ b/apps/worker/src/utils/authentication.ts
@@ -4,7 +4,10 @@ import {
   playerIdSchema
 } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type RequestWithId } from '../types/itty'
+import {
+  type AuthenticatedRequestWithProps,
+  type RequestWithId
+} from '../types/itty'
 import { hashCredential } from './credentials'
 import { apiError } from './http'
 
@@ -13,7 +16,8 @@ interface PlayerIdentityRow {
 }
 
 interface PlayerRequest extends RequestWithId {
-  playerId: string
+  playerId?: string
+  principal?: AuthenticatedRequestWithProps['principal']
 }
 
 export async function authenticatePlayerRequest(
@@ -49,11 +53,17 @@ export async function authenticatePlayerRequest(
     })
   }
 
+  request.principal = { playerId: authenticatedPlayerId.data }
+
   const isAiSetup =
     request.playerId === AI_PLAYER_ID &&
     new URL(request.url).pathname.endsWith(`/${AI_PLAYER_ID}/init`)
 
-  if (request.playerId !== authenticatedPlayerId.data && !isAiSetup) {
+  if (
+    request.playerId !== undefined &&
+    request.playerId !== authenticatedPlayerId.data &&
+    !isAiSetup
+  ) {
     return apiError({
       status: 403,
       code: 'PLAYER_ID_MISMATCH',

--- a/apps/worker/src/utils/authoritativeGame.ts
+++ b/apps/worker/src/utils/authoritativeGame.ts
@@ -1,0 +1,44 @@
+import {
+  GameState,
+  gameStateSchema,
+  type IGameState,
+  type PlayGameCommand,
+  type PlayIntentRejectionReason
+} from '@knucklebones/common'
+
+type AuthoritativePlayResult =
+  | { status: 'rejected'; reason: PlayIntentRejectionReason }
+  | { status: 'updated'; gameState: GameState }
+
+export function applyPlayCommand(
+  serializedGameState: IGameState | undefined,
+  command: PlayGameCommand
+): AuthoritativePlayResult {
+  if (serializedGameState === undefined) {
+    return { status: 'rejected', reason: 'game-not-initialized' }
+  }
+
+  const parsedGameState = gameStateSchema.safeParse(serializedGameState)
+  if (!parsedGameState.success) {
+    return { status: 'rejected', reason: 'invalid-game-state' }
+  }
+
+  const gameState = GameState.fromJson(parsedGameState.data)
+
+  if (
+    command.expectedRevision !== undefined &&
+    command.expectedRevision !== gameState.revision
+  ) {
+    return { status: 'rejected', reason: 'stale-revision' }
+  }
+
+  const rejectionReason = gameState.applyPlayIntent(
+    command.actorId,
+    command.column
+  )
+  if (rejectionReason !== undefined) {
+    return { status: 'rejected', reason: rejectionReason }
+  }
+
+  return { status: 'updated', gameState }
+}

--- a/apps/worker/src/utils/endpoints.ts
+++ b/apps/worker/src/utils/endpoints.ts
@@ -1,14 +1,16 @@
 import { type IGameState, toGameStateMessage } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type BaseRequestWithProps } from '../types/itty'
+import { type DurableRoomRequestWithProps } from '../types/itty'
 
-export function getGameStateDurableObject(request: BaseRequestWithProps) {
+export function getGameStateDurableObject(
+  request: DurableRoomRequestWithProps
+) {
   return request.GAME_STATE_DURABLE_OBJECT.get(request.roomKey)
 }
 
 export async function broadcastGameState(
   gameState: IGameState,
-  request: BaseRequestWithProps,
+  request: DurableRoomRequestWithProps,
   cloudflareEnvironment: CloudflareEnvironment
 ) {
   const roomKey = request.roomKey

--- a/apps/worker/src/utils/idempotency.ts
+++ b/apps/worker/src/utils/idempotency.ts
@@ -1,17 +1,24 @@
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type MutationRequestWithProps } from '../types/itty'
+import {
+  type AuthenticatedMutationRoomRequestWithProps,
+  type MutationRequestWithProps,
+  type RequestWithId,
+  type RequestWithMutationId
+} from '../types/itty'
 import { apiError } from './http'
 
 const IDEMPOTENCY_KEY_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 
-type MutationMiddleware = (
-  request: Request & MutationRequestWithProps,
+type MutationMiddleware<TRequest> = (
+  request: Request & TRequest,
   cloudflareEnvironment: CloudflareEnvironment,
   context: ExecutionContext
 ) => Response | undefined
 
-export const withMutationId: MutationMiddleware = (request) => {
+function assignMutationId(
+  request: Request & RequestWithId & Partial<RequestWithMutationId>
+): Response | undefined {
   const mutationId = request.headers.get('Idempotency-Key')
 
   if (mutationId === null) {
@@ -30,6 +37,12 @@ export const withMutationId: MutationMiddleware = (request) => {
 
   request.mutationId = mutationId
 }
+
+export const withMutationId: MutationMiddleware<MutationRequestWithProps> =
+  assignMutationId
+
+export const withAuthenticatedMutationId: MutationMiddleware<AuthenticatedMutationRoomRequestWithProps> =
+  assignMutationId
 
 export function idempotencyConflict(requestId: string): Response {
   return apiError({

--- a/apps/worker/src/utils/play.ts
+++ b/apps/worker/src/utils/play.ts
@@ -1,0 +1,31 @@
+import {
+  idempotentPlayGameResultSchema,
+  type PlayGameResult
+} from '@knucklebones/common'
+import {
+  type DurableRoomRequestWithProps,
+  type RequestWithMutationId
+} from '../types/itty'
+import { getGameStateDurableObject } from './endpoints'
+
+export async function applyAuthoritativePlay(
+  request: DurableRoomRequestWithProps & RequestWithMutationId,
+  actorId: string,
+  column: number,
+  expectedRevision?: number
+) {
+  return idempotentPlayGameResultSchema.parse(
+    await getGameStateDurableObject(request).play({
+      mutationId: request.mutationId,
+      actorId,
+      column,
+      expectedRevision
+    })
+  )
+}
+
+export function getAppliedPlayResult(
+  result: Awaited<ReturnType<typeof applyAuthoritativePlay>>
+): PlayGameResult | undefined {
+  return result.idempotencyStatus === 'conflict' ? undefined : result.value
+}

--- a/apps/worker/src/utils/validation.ts
+++ b/apps/worker/src/utils/validation.ts
@@ -30,6 +30,12 @@ export function validateRequestPath(
       : invalidRouteParameters(request.requestId)
   }
 
+  if (segments[0] === 'v1' && segments[1] === 'rooms') {
+    return roomKeySchema.safeParse(segments[2]).success
+      ? undefined
+      : invalidRouteParameters(request.requestId)
+  }
+
   if (segments.length >= 3) {
     const isValid =
       roomKeySchema.safeParse(segments[0]).success &&

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -12,6 +12,7 @@ import {
   joinMatchmaking,
   leaveMatchmaking,
   play,
+  playIntent,
   rematch,
   verifyPlayer,
   webSocket
@@ -24,7 +25,10 @@ import {
   sanitizeRequestForSentry,
   withRequestId
 } from '../utils/http'
-import { withMutationId } from '../utils/idempotency'
+import {
+  withAuthenticatedMutationId,
+  withMutationId
+} from '../utils/idempotency'
 import { validateRequestPath } from '../utils/validation'
 
 export { GameStateDurableObject } from '../durable-objects/GameStateDurableObject'
@@ -49,6 +53,12 @@ router
   .post('/matchmaking/:playerId/join', joinMatchmaking)
   .get('/matchmaking/:playerId/status', getMatchmakingStatus)
   .delete('/matchmaking/:playerId/queue', leaveMatchmaking)
+  .all(
+    '/v1/rooms/:roomKey/*',
+    withDurables({ parse: true }),
+    authenticatePlayerRequest
+  )
+  .post('/v1/rooms/:roomKey/play', withAuthenticatedMutationId, playIntent)
   .all(
     '/:roomKey/:playerId/*',
     withDurables({ parse: true }),

--- a/apps/worker/test/authoritativeGame.test.ts
+++ b/apps/worker/test/authoritativeGame.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GameState,
+  type IGameState,
+  Player,
+  type PlayGameCommand
+} from '@knucklebones/common'
+import { applyPlayCommand } from '../src/utils/authoritativeGame'
+
+const playerOneId = '11111111-1111-4111-8111-111111111111'
+const playerTwoId = '22222222-2222-4222-8222-222222222222'
+
+function createGameState() {
+  const playerOne = new Player(playerOneId, undefined, undefined, 4)
+  const playerTwo = new Player(playerTwoId)
+
+  return new GameState({
+    revision: 2,
+    playerOne,
+    playerTwo,
+    nextPlayer: playerOne,
+    outcome: 'ongoing',
+    boType: 1
+  }).toJson()
+}
+
+function command(overrides: Partial<PlayGameCommand> = {}): PlayGameCommand {
+  return {
+    mutationId: '33333333-3333-4333-8333-333333333333',
+    actorId: playerOneId,
+    column: 0,
+    expectedRevision: 2,
+    ...overrides
+  }
+}
+
+describe('applyPlayCommand', () => {
+  it('applies a column intent using the server-issued die', () => {
+    const result = applyPlayCommand(createGameState(), command())
+
+    expect(result.status).toBe('updated')
+    if (result.status !== 'updated') {
+      throw new Error('Expected the play intent to be applied.')
+    }
+    expect(result.gameState.playerOne.columns).toEqual([[4], [], []])
+  })
+
+  it('rejects a stale command without mutating its snapshot', () => {
+    const gameState = createGameState()
+    const originalGameState = structuredClone(gameState)
+
+    expect(
+      applyPlayCommand(gameState, command({ expectedRevision: 1 }))
+    ).toEqual({ status: 'rejected', reason: 'stale-revision' })
+    expect(gameState).toEqual(originalGameState)
+  })
+
+  it('rejects missing and malformed authoritative state', () => {
+    expect(applyPlayCommand(undefined, command())).toEqual({
+      status: 'rejected',
+      reason: 'game-not-initialized'
+    })
+
+    const malformed = {
+      ...createGameState(),
+      playerOne: { ...createGameState().playerOne, columns: [[1, 2, 3, 4]] }
+    } as IGameState
+    expect(applyPlayCommand(malformed, command())).toEqual({
+      status: 'rejected',
+      reason: 'invalid-game-state'
+    })
+  })
+})

--- a/apps/worker/test/worker.integration.test.ts
+++ b/apps/worker/test/worker.integration.test.ts
@@ -216,6 +216,56 @@ describe('runtime request validation', () => {
       expect(response.headers.get('X-Request-Id')).toBe(body.error.requestId)
     }
   })
+
+  it('accepts only column intent and derives the actor from authentication', async () => {
+    const playerOne = await createPlayer()
+    const playerTwo = await createPlayer()
+    const spectator = await createPlayer()
+    const roomKey = crypto.randomUUID()
+
+    for (const player of [playerOne, playerTwo]) {
+      const response = await request(`/${roomKey}/${player.playerId}/init`, {
+        method: 'POST',
+        headers: {
+          ...authorization(player),
+          'Idempotency-Key': crypto.randomUUID()
+        }
+      })
+      expect(response.status).toBe(200)
+    }
+
+    const submittedFacts = await request(`/v1/rooms/${roomKey}/play`, {
+      method: 'POST',
+      headers: {
+        ...authorization(playerOne),
+        'Content-Type': 'application/json',
+        'Idempotency-Key': crypto.randomUUID()
+      },
+      body: JSON.stringify({
+        column: 0,
+        author: playerTwo.playerId,
+        dice: 6
+      })
+    })
+    const spectatorMove = await request(`/v1/rooms/${roomKey}/play`, {
+      method: 'POST',
+      headers: {
+        ...authorization(spectator),
+        'Content-Type': 'application/json',
+        'Idempotency-Key': crypto.randomUUID()
+      },
+      body: JSON.stringify({ column: 0 })
+    })
+
+    expect(submittedFacts.status).toBe(400)
+    await expect(submittedFacts.json()).resolves.toMatchObject({
+      error: { code: 'INVALID_PLAY_INTENT' }
+    })
+    expect(spectatorMove.status).toBe(403)
+    await expect(spectatorMove.json()).resolves.toMatchObject({
+      error: { code: 'NOT_A_PLAYER' }
+    })
+  })
 })
 
 describe('WebSocket tickets', () => {

--- a/packages/common/src/classes/GameState.test.ts
+++ b/packages/common/src/classes/GameState.test.ts
@@ -15,6 +15,40 @@ function createGameState() {
 }
 
 describe('GameState play validation', () => {
+  it('derives the die and actor state from a column-only intent', () => {
+    const gameState = createGameState()
+
+    expect(gameState.applyPlayIntent('player-one', 1)).toBeUndefined()
+
+    expect(gameState.playerOne.columns).toEqual([[], [4], []])
+    expect(gameState.nextPlayer.id).toBe('player-two')
+  })
+
+  it.each([
+    ['unknown-player', 'spectator', 0],
+    ['not-player-turn', 'player-two', 0],
+    ['invalid-column', 'player-one', 3]
+  ] as const)(
+    'rejects a %s play intent without changing state',
+    (reason, actorId, column) => {
+      const gameState = createGameState()
+      const originalState = gameState.toJson()
+
+      expect(gameState.applyPlayIntent(actorId, column)).toBe(reason)
+      expect(gameState.toJson()).toEqual(originalState)
+    }
+  )
+
+  it('rejects an inconsistent server-issued die', () => {
+    const gameState = createGameState()
+    gameState.nextPlayer = new Player('player-one', 'Player One', undefined, 3)
+
+    expect(gameState.applyPlayIntent('player-one', 0)).toBe(
+      'invalid-game-state'
+    )
+    expect(gameState.playerOne.columns).toEqual([[], [], []])
+  })
+
   it('applies a valid move and advances the turn', () => {
     const gameState = createGameState()
 

--- a/packages/common/src/classes/GameState.ts
+++ b/packages/common/src/classes/GameState.ts
@@ -2,6 +2,7 @@ import { type IGameState, type IPlayer } from '../interfaces'
 import {
   type Outcome,
   type Play,
+  type PlayIntentRejectionReason,
   type OutcomeHistory,
   type PlayRejectionReason,
   type PlayerOutcome,
@@ -148,6 +149,77 @@ export class GameState implements IGameState {
 
     const [player] = this.getPlayers(play.author)
     if (player.columns[play.column].length >= 3) {
+      return 'column-full'
+    }
+  }
+
+  applyPlayIntent(
+    actorId: string,
+    column: number
+  ): PlayIntentRejectionReason | undefined {
+    const rejectionReason = this.getPlayIntentRejectionReason(actorId, column)
+    if (rejectionReason !== undefined) {
+      return rejectionReason
+    }
+
+    this.applyPlay({
+      author: actorId,
+      column,
+      dice: this.nextPlayer.dice!
+    })
+  }
+
+  private getPlayIntentRejectionReason(
+    actorId: string,
+    column: number
+  ): PlayIntentRejectionReason | undefined {
+    if (this.outcome !== 'ongoing') {
+      return 'game-ended'
+    }
+
+    if (this.playerOne.id === this.playerTwo.id) {
+      return 'invalid-game-state'
+    }
+
+    const actor =
+      actorId === this.playerOne.id
+        ? this.playerOne
+        : actorId === this.playerTwo.id
+          ? this.playerTwo
+          : undefined
+
+    if (actor === undefined) {
+      return 'unknown-player'
+    }
+
+    const nextPlayerId = this.nextPlayer.id
+    if (
+      nextPlayerId !== this.playerOne.id &&
+      nextPlayerId !== this.playerTwo.id
+    ) {
+      return 'invalid-game-state'
+    }
+
+    if (actorId !== nextPlayerId) {
+      return 'not-player-turn'
+    }
+
+    const dice = this.nextPlayer.dice
+    if (
+      dice === undefined ||
+      !Number.isInteger(dice) ||
+      dice < 1 ||
+      dice > 6 ||
+      actor.dice !== dice
+    ) {
+      return 'invalid-game-state'
+    }
+
+    if (!Number.isInteger(column) || column < 0 || column > 2) {
+      return 'invalid-column'
+    }
+
+    if (actor.columns[column].length >= 3) {
       return 'column-full'
     }
   }

--- a/packages/common/src/schemas/api.ts
+++ b/packages/common/src/schemas/api.ts
@@ -40,6 +40,10 @@ export const playRouteParamsSchema = z.object({
   dice: z.enum(['1', '2', '3', '4', '5', '6'])
 })
 
+export const playIntentSchema = z.strictObject({
+  column: z.union([z.literal(0), z.literal(1), z.literal(2)])
+})
+
 export const gameSettingsQuerySchema = z.object({
   boType: z.optional(z.enum(['indefinite', '1', '3', '5'])),
   difficulty: z.optional(z.enum(['easy', 'medium', 'hard']))

--- a/packages/common/src/schemas/durableObject.test.ts
+++ b/packages/common/src/schemas/durableObject.test.ts
@@ -25,18 +25,18 @@ describe('Durable Object result contracts', () => {
     expect(
       playGameCommandSchema.parse({
         mutationId: '11111111-1111-4111-8111-111111111111',
-        play: {
-          author: '22222222-2222-4222-8222-222222222222',
-          column: 2,
-          dice: 6
-        }
+        actorId: '22222222-2222-4222-8222-222222222222',
+        column: 2,
+        expectedRevision: 4
       })
-    ).toMatchObject({ play: { column: 2, dice: 6 } })
+    ).toMatchObject({ column: 2, expectedRevision: 4 })
 
     expect(
       playGameCommandSchema.safeParse({
         mutationId: 'not-a-mutation-id',
-        play: { author: 'not-a-player-id', column: 3, dice: 7 }
+        actorId: 'not-a-player-id',
+        column: 3,
+        expectedRevision: -1
       }).success
     ).toBe(false)
   })
@@ -56,11 +56,11 @@ describe('Durable Object result contracts', () => {
     expect(
       idempotentPlayGameResultSchema.parse({
         idempotencyStatus: 'replayed',
-        value: { status: 'rejected', reason: 'not-player-turn' }
+        value: { status: 'rejected', reason: 'stale-revision' }
       })
     ).toEqual({
       idempotencyStatus: 'replayed',
-      value: { status: 'rejected', reason: 'not-player-turn' }
+      value: { status: 'rejected', reason: 'stale-revision' }
     })
     expect(
       idempotentPlayGameResultSchema.parse({

--- a/packages/common/src/schemas/durableObject.ts
+++ b/packages/common/src/schemas/durableObject.ts
@@ -31,11 +31,9 @@ export const initializeGameCommandSchema = z.object({
 
 export const playGameCommandSchema = z.object({
   mutationId: mutationIdSchema,
-  play: z.object({
-    dice: z.int().check(z.minimum(1), z.maximum(6)),
-    column: z.int().check(z.minimum(0), z.maximum(2)),
-    author: gamePlayerIdSchema
-  })
+  actorId: gamePlayerIdSchema,
+  column: z.int().check(z.minimum(0), z.maximum(2)),
+  expectedRevision: z.optional(z.int().check(z.minimum(0)))
 })
 
 export const rematchGameCommandSchema = z.object({
@@ -77,12 +75,14 @@ export const playGameResultSchema = z.union([
   z.object({
     status: z.literal('rejected'),
     reason: z.enum([
+      'game-not-initialized',
       'game-ended',
       'unknown-player',
       'not-player-turn',
-      'unexpected-die',
       'invalid-column',
-      'column-full'
+      'column-full',
+      'invalid-game-state',
+      'stale-revision'
     ])
   }),
   updatedGameStateResultSchema

--- a/packages/common/src/types/durableObject.ts
+++ b/packages/common/src/types/durableObject.ts
@@ -1,6 +1,6 @@
 import { type IGameState } from '../interfaces'
 import { type BoType, type Difficulty, type GameSettings } from './gameSettings'
-import { type Play, type PlayRejectionReason } from './play'
+import { type PlayIntentRejectionReason } from './play'
 
 export interface InitializeGameCommand {
   mutationId: string
@@ -12,7 +12,9 @@ export interface InitializeGameCommand {
 
 export interface PlayGameCommand {
   mutationId: string
-  play: Play
+  actorId: string
+  column: number
+  expectedRevision?: number
 }
 
 export interface RematchGameCommand {
@@ -39,7 +41,7 @@ export type UpdateDisplayNameResult =
   { status: 'unknown-player' } | { status: 'updated'; gameState: IGameState }
 
 export type PlayGameResult =
-  | { status: 'rejected'; reason: PlayRejectionReason }
+  | { status: 'rejected'; reason: PlayIntentRejectionReason }
   | { status: 'updated'; gameState: IGameState }
 
 export type GameStateMutationResult =

--- a/packages/common/src/types/play.ts
+++ b/packages/common/src/types/play.ts
@@ -4,6 +4,10 @@ export interface Play {
   author: string
 }
 
+export interface PlayIntent {
+  column: 0 | 1 | 2
+}
+
 export type PlayRejectionReason =
   | 'game-ended'
   | 'unknown-player'
@@ -11,3 +15,13 @@ export type PlayRejectionReason =
   | 'unexpected-die'
   | 'invalid-column'
   | 'column-full'
+
+export type PlayIntentRejectionReason =
+  | 'game-not-initialized'
+  | 'game-ended'
+  | 'unknown-player'
+  | 'not-player-turn'
+  | 'invalid-column'
+  | 'column-full'
+  | 'invalid-game-state'
+  | 'stale-revision'

--- a/packages/common/src/types/playerIdentity.ts
+++ b/packages/common/src/types/playerIdentity.ts
@@ -9,3 +9,8 @@ export interface WebSocketTicket {
   ticket: string
   expiresAt: number
 }
+
+export interface AuthenticatedPrincipal {
+  playerId: string
+  credentialId?: string
+}

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -75,6 +75,16 @@ test('starts a hard BO1 AI game with valid versioned state updates', async ({
   await expect(page.getByText('Waiting for game to start...')).toHaveCount(0)
   await expect.poll(() => gameStateMessages.length).toBeGreaterThan(0)
 
+  const columns = page.locator('div[role="button"]')
+  await expect(columns).toHaveCount(3)
+  const messagesBeforeHumanMove = gameStateMessages.length
+  await columns.first().click()
+  await expect(columns).toHaveCount(0)
+  await expect(columns).toHaveCount(3)
+  await expect
+    .poll(() => gameStateMessages.length)
+    .toBeGreaterThan(messagesBeforeHumanMove + 1)
+
   for (const [index, message] of gameStateMessages.entries()) {
     expect(message).toMatchObject({
       type: 'game.state',


### PR DESCRIPTION
## Summary

- add a versioned column-only play-intent endpoint that derives the actor from authentication and the die from authoritative room state
- centralize intent validation in the shared game model, including membership, turn, board, outcome, and server-die consistency checks
- bind delayed AI moves to the snapshot revision so stale actions are discarded and safely rescheduled
- keep the legacy play route temporarily compatible while ignoring its client-supplied die
- cover malformed facts, spectators, stale revisions, AI replies, optimistic play, and two-browser synchronization