### PR TITLE
feat(identity): harden credential infrastructure

### DIFF
--- a/apps/front/src/components/GameContext/useGameSetup.ts
+++ b/apps/front/src/components/GameContext/useGameSetup.ts
@@ -19,6 +19,7 @@ import {
   play,
   voteRematch
 } from '../../utils/api'
+import { getStoredPlayerId } from '../../utils/identityStorage'
 import { getPlayerFromId, getPlayerSide } from '../../utils/player'
 import { getWebSocketUrl, preparePlayers } from './utils'
 
@@ -38,7 +39,7 @@ export function useGameSetup() {
   const roomKey = useRoomKey()
   const latestRevision = React.useRef({ roomKey, value: -1 })
   const state = useLocation().state as GameSettings | undefined
-  const playerId = localStorage.getItem('playerId')!
+  const playerId = getStoredPlayerId()!
   const getAuthenticatedWebSocketUrl = React.useCallback(async () => {
     const { ticket } = await createWebSocketTicket({ roomKey, playerId })
     return getWebSocketUrl(roomKey, ticket)

--- a/apps/front/src/components/PlayerBoard/Name.test.tsx
+++ b/apps/front/src/components/PlayerBoard/Name.test.tsx
@@ -32,7 +32,9 @@ describe('Name', () => {
     const generatedName = updateDisplayName.mock.calls[0][0] as string
     expect(generatedName).not.toBe(playerId)
     expect(generatedName).toMatch(/^[A-Z][A-Za-z]+$/)
-    expect(localStorage.getItem('displayName')).toBe(generatedName)
+    expect(localStorage.getItem('knucklebones.identity.v1.displayName')).toBe(
+      generatedName
+    )
     expect(screen.getByText(new RegExp(generatedName))).toBeInTheDocument()
   })
 })

--- a/apps/front/src/components/PlayerBoard/Name.tsx
+++ b/apps/front/src/components/PlayerBoard/Name.tsx
@@ -6,6 +6,7 @@ import {
   XMarkIcon
 } from '@heroicons/react/24/outline'
 import { isEmptyOrBlank } from '@knucklebones/common'
+import { storeDisplayName } from '../../utils/identityStorage'
 import {
   MAX_NAME_LENGTH,
   type PlayerNameProps,
@@ -59,7 +60,7 @@ export function Name({
 
     if (isEmptyOrBlank(name)) {
       const generatedName = randomName()
-      localStorage.setItem('displayName', generatedName)
+      storeDisplayName(generatedName)
       setName(generatedName)
       updateDisplayName!(generatedName)
     } else {
@@ -68,13 +69,13 @@ export function Name({
           // If the name displayed was the id, and the new name
           // is different from the id the player is trying to set a
           // displayName, so set it in local storage and send it to the backend
-          localStorage.setItem('displayName', name)
+          storeDisplayName(name)
           updateDisplayName!(name)
         }
       } else {
         if (name !== displayName) {
           // Same case as above, but the player is trying to update their displayName
-          localStorage.setItem('displayName', name)
+          storeDisplayName(name)
           updateDisplayName!(name)
         }
       }

--- a/apps/front/src/utils/api.ts
+++ b/apps/front/src/utils/api.ts
@@ -14,6 +14,10 @@ import {
   type WebSocketTicket,
   webSocketTicketSchema
 } from '@knucklebones/common'
+import {
+  getStoredDeviceCredential,
+  getStoredDisplayName
+} from './identityStorage'
 
 type Method = 'GET' | 'POST' | 'DELETE'
 
@@ -134,8 +138,11 @@ export async function initGame(
 
   if (playerType === 'ai' && difficulty !== undefined) {
     urlSearchParams.append('difficulty', difficulty)
-  } else if ('displayName' in localStorage) {
-    urlSearchParams.append('displayName', localStorage.displayName)
+  } else {
+    const displayName = getStoredDisplayName()
+    if (displayName !== null) {
+      urlSearchParams.append('displayName', displayName)
+    }
   }
 
   if (boType !== undefined) {
@@ -212,7 +219,7 @@ async function sendApiRequest(
   path: string,
   method: Method,
   body?: unknown,
-  credential = localStorage.getItem('playerCredential'),
+  credential = getStoredDeviceCredential(),
   mutationId?: string
 ) {
   const headers = {

--- a/apps/front/src/utils/identityStorage.ts
+++ b/apps/front/src/utils/identityStorage.ts
@@ -1,0 +1,69 @@
+const PLAYER_ID_KEY = 'knucklebones.identity.v1.playerId'
+const PLAYER_CREDENTIAL_KEY = 'knucklebones.identity.v1.deviceCredential'
+const DISPLAY_NAME_KEY = 'knucklebones.identity.v1.displayName'
+const PENDING_RECOVERY_PHRASE_KEY =
+  'knucklebones.identity.v1.pendingRecoveryPhrase'
+const RECOVERY_CONFIRMED_KEY = 'knucklebones.identity.v1.recoveryConfirmed'
+
+const LEGACY_PLAYER_ID_KEY = 'playerId'
+const LEGACY_PLAYER_CREDENTIAL_KEY = 'playerCredential'
+const LEGACY_DISPLAY_NAME_KEY = 'displayName'
+
+export function migrateLegacyIdentityStorage(): void {
+  migrateKey(LEGACY_PLAYER_ID_KEY, PLAYER_ID_KEY)
+  migrateKey(LEGACY_PLAYER_CREDENTIAL_KEY, PLAYER_CREDENTIAL_KEY)
+  migrateKey(LEGACY_DISPLAY_NAME_KEY, DISPLAY_NAME_KEY)
+}
+
+export function getStoredPlayerId(): string | null {
+  migrateLegacyIdentityStorage()
+  return localStorage.getItem(PLAYER_ID_KEY)
+}
+
+export function getStoredDeviceCredential(): string | null {
+  migrateLegacyIdentityStorage()
+  return localStorage.getItem(PLAYER_CREDENTIAL_KEY)
+}
+
+export function storeIdentity(playerId: string, credential: string): void {
+  localStorage.setItem(PLAYER_ID_KEY, playerId)
+  localStorage.setItem(PLAYER_CREDENTIAL_KEY, credential)
+  localStorage.removeItem(LEGACY_PLAYER_ID_KEY)
+  localStorage.removeItem(LEGACY_PLAYER_CREDENTIAL_KEY)
+}
+
+export function getStoredDisplayName(): string | null {
+  migrateLegacyIdentityStorage()
+  return localStorage.getItem(DISPLAY_NAME_KEY)
+}
+
+export function storeDisplayName(displayName: string): void {
+  localStorage.setItem(DISPLAY_NAME_KEY, displayName)
+  localStorage.removeItem(LEGACY_DISPLAY_NAME_KEY)
+}
+
+export function getPendingRecoveryPhrase(): string | undefined {
+  return localStorage.getItem(PENDING_RECOVERY_PHRASE_KEY) ?? undefined
+}
+
+export function storePendingRecoveryPhrase(recoveryPhrase: string): void {
+  localStorage.setItem(PENDING_RECOVERY_PHRASE_KEY, recoveryPhrase)
+  localStorage.removeItem(RECOVERY_CONFIRMED_KEY)
+}
+
+export function confirmRecoveryPhrase(): void {
+  localStorage.removeItem(PENDING_RECOVERY_PHRASE_KEY)
+  localStorage.setItem(RECOVERY_CONFIRMED_KEY, 'true')
+}
+
+function migrateKey(legacyKey: string, versionedKey: string): void {
+  const versionedValue = localStorage.getItem(versionedKey)
+  const legacyValue = localStorage.getItem(legacyKey)
+
+  if (versionedValue === null && legacyValue !== null) {
+    localStorage.setItem(versionedKey, legacyValue)
+  }
+  if (localStorage.getItem(versionedKey) !== null) {
+    localStorage.removeItem(legacyKey)
+  }
+}

--- a/apps/front/src/utils/playerIdentity.test.ts
+++ b/apps/front/src/utils/playerIdentity.test.ts
@@ -31,7 +31,9 @@ describe('ensurePlayerIdentity', () => {
     expect(
       localStorage.getItem('knucklebones.identity.v1.pendingRecoveryPhrase')
     ).toBe(bootstrap.recoveryPhrase)
-    expect(localStorage.getItem('displayName')).toBe('BraveBlueFox')
+    expect(localStorage.getItem('knucklebones.identity.v1.displayName')).toBe(
+      'BraveBlueFox'
+    )
   })
 
   it('adds a friendly name to an existing UUID identity', async () => {
@@ -41,7 +43,11 @@ describe('ensurePlayerIdentity', () => {
     await ensurePlayerIdentity()
 
     expect(createPlayer).not.toHaveBeenCalled()
-    expect(localStorage.getItem('displayName')).toBe('BraveBlueFox')
+    expect(localStorage.getItem('knucklebones.identity.v1.displayName')).toBe(
+      'BraveBlueFox'
+    )
+    expect(localStorage.getItem('playerId')).toBeNull()
+    expect(localStorage.getItem('playerCredential')).toBeNull()
   })
 
   it('preserves a user-selected display name', async () => {
@@ -51,6 +57,8 @@ describe('ensurePlayerIdentity', () => {
 
     await ensurePlayerIdentity()
 
-    expect(localStorage.getItem('displayName')).toBe('Custom Name')
+    expect(localStorage.getItem('knucklebones.identity.v1.displayName')).toBe(
+      'Custom Name'
+    )
   })
 })

--- a/apps/front/src/utils/playerIdentity.ts
+++ b/apps/front/src/utils/playerIdentity.ts
@@ -3,26 +3,32 @@ import {
   playerCredentialsSchema
 } from '@knucklebones/common'
 import { createPlayer } from './api'
+import {
+  getStoredDeviceCredential,
+  getStoredDisplayName,
+  getStoredPlayerId,
+  storeDisplayName,
+  storeIdentity,
+  storePendingRecoveryPhrase
+} from './identityStorage'
 import { randomName } from './name'
 
-const PLAYER_ID_KEY = 'playerId'
-const PLAYER_CREDENTIAL_KEY = 'playerCredential'
-const DISPLAY_NAME_KEY = 'displayName'
-const PENDING_RECOVERY_PHRASE_KEY =
-  'knucklebones.identity.v1.pendingRecoveryPhrase'
-const RECOVERY_CONFIRMED_KEY = 'knucklebones.identity.v1.recoveryConfirmed'
+export {
+  confirmRecoveryPhrase,
+  getPendingRecoveryPhrase,
+  storePendingRecoveryPhrase
+} from './identityStorage'
 
 export function getStoredPlayerCredentials(): PlayerCredentials | undefined {
   const result = playerCredentialsSchema.safeParse({
-    playerId: localStorage.getItem(PLAYER_ID_KEY),
-    credential: localStorage.getItem(PLAYER_CREDENTIAL_KEY)
+    playerId: getStoredPlayerId(),
+    credential: getStoredDeviceCredential()
   })
   return result.success ? result.data : undefined
 }
 
 export function storePlayerCredentials(credentials: PlayerCredentials): void {
-  localStorage.setItem(PLAYER_ID_KEY, credentials.playerId)
-  localStorage.setItem(PLAYER_CREDENTIAL_KEY, credentials.credential)
+  storeIdentity(credentials.playerId, credentials.credential)
 }
 
 export async function ensurePlayerIdentity(): Promise<PlayerCredentials> {
@@ -39,22 +45,8 @@ export async function ensurePlayerIdentity(): Promise<PlayerCredentials> {
   return credentials
 }
 
-export function getPendingRecoveryPhrase(): string | undefined {
-  return localStorage.getItem(PENDING_RECOVERY_PHRASE_KEY) ?? undefined
-}
-
-export function storePendingRecoveryPhrase(recoveryPhrase: string): void {
-  localStorage.setItem(PENDING_RECOVERY_PHRASE_KEY, recoveryPhrase)
-  localStorage.removeItem(RECOVERY_CONFIRMED_KEY)
-}
-
-export function confirmRecoveryPhrase(): void {
-  localStorage.removeItem(PENDING_RECOVERY_PHRASE_KEY)
-  localStorage.setItem(RECOVERY_CONFIRMED_KEY, 'true')
-}
-
 function ensurePlayerDisplayName(): void {
-  if (localStorage.getItem(DISPLAY_NAME_KEY) === null) {
-    localStorage.setItem(DISPLAY_NAME_KEY, randomName())
+  if (getStoredDisplayName() === null) {
+    storeDisplayName(randomName())
   }
 }

--- a/apps/worker/migrations/0006_create_rate_limit_buckets.sql
+++ b/apps/worker/migrations/0006_create_rate_limit_buckets.sql
@@ -1,0 +1,9 @@
+CREATE TABLE rate_limit_buckets (
+  bucket_key TEXT PRIMARY KEY NOT NULL CHECK (length(bucket_key) = 64),
+  window_started_at INTEGER NOT NULL,
+  request_count INTEGER NOT NULL CHECK (request_count > 0),
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX rate_limit_buckets_updated
+  ON rate_limit_buckets (updated_at);

--- a/apps/worker/src/endpoints/createPlayer.ts
+++ b/apps/worker/src/endpoints/createPlayer.ts
@@ -1,15 +1,26 @@
 import { type PlayerIdentityBootstrap } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
+import { type RequestWithId } from '../types/itty'
 import {
   createDeviceCredential,
   createRecoveryPhrase,
   hashCredential
 } from '../utils/credentials'
+import { enforceRateLimit } from '../utils/rateLimit'
 
 export async function createPlayer(
-  _request: Request,
+  request: Request & RequestWithId,
   cloudflareEnvironment: CloudflareEnvironment
 ): Promise<Response> {
+  const rateLimit = await enforceRateLimit(
+    request,
+    cloudflareEnvironment.PLAYERS_DB,
+    { scope: 'identity-create', limit: 30, windowMs: 60 * 60 * 1000 }
+  )
+  if (rateLimit !== undefined) {
+    return rateLimit
+  }
+
   const playerId = crypto.randomUUID()
   const { credentialId, credential, secretHash } =
     await createDeviceCredential()

--- a/apps/worker/src/endpoints/identityRecovery.ts
+++ b/apps/worker/src/endpoints/identityRecovery.ts
@@ -14,15 +14,30 @@ import {
   hashCredential
 } from '../utils/credentials'
 import { apiError } from '../utils/http'
+import { enforceRateLimit } from '../utils/rateLimit'
 
 interface IdentityRecoveryRow {
   player_id: string
 }
 
 export async function rotateIdentityRecovery(
-  request: AuthenticatedRequestWithProps,
+  request: Request & AuthenticatedRequestWithProps,
   cloudflareEnvironment: CloudflareEnvironment
 ): Promise<Response> {
+  const rateLimit = await enforceRateLimit(
+    request,
+    cloudflareEnvironment.PLAYERS_DB,
+    {
+      scope: 'identity-recovery-rotate',
+      identifier: request.principal.playerId,
+      limit: 10,
+      windowMs: 60 * 60 * 1000
+    }
+  )
+  if (rateLimit !== undefined) {
+    return rateLimit
+  }
+
   const recoveryPhrase = createRecoveryPhrase()
   const rotatedAt = Date.now()
 
@@ -53,6 +68,19 @@ export async function redeemIdentityRecovery(
   request: Request & RequestWithId,
   cloudflareEnvironment: CloudflareEnvironment
 ): Promise<Response> {
+  const rateLimit = await enforceRateLimit(
+    request,
+    cloudflareEnvironment.PLAYERS_DB,
+    {
+      scope: 'identity-recovery-redeem',
+      limit: 10,
+      windowMs: 15 * 60 * 1000
+    }
+  )
+  if (rateLimit !== undefined) {
+    return rateLimit
+  }
+
   const rawBody = (await request.json().catch(() => undefined)) as
     Record<string, unknown> | undefined
   const body = redeemIdentityRecoveryRequestSchema.safeParse({

--- a/apps/worker/src/endpoints/identityTransfers.ts
+++ b/apps/worker/src/endpoints/identityTransfers.ts
@@ -14,6 +14,7 @@ import {
   hashCredential
 } from '../utils/credentials'
 import { apiError } from '../utils/http'
+import { enforceRateLimit } from '../utils/rateLimit'
 
 const IDENTITY_TRANSFER_TTL_MS = 10 * 60 * 1000
 
@@ -22,9 +23,23 @@ interface IdentityTransferRedemptionRow {
 }
 
 export async function createIdentityTransfer(
-  request: AuthenticatedRequestWithProps,
+  request: Request & AuthenticatedRequestWithProps,
   cloudflareEnvironment: CloudflareEnvironment
 ): Promise<Response> {
+  const rateLimit = await enforceRateLimit(
+    request,
+    cloudflareEnvironment.PLAYERS_DB,
+    {
+      scope: 'identity-transfer-create',
+      identifier: request.principal.playerId,
+      limit: 20,
+      windowMs: 60 * 60 * 1000
+    }
+  )
+  if (rateLimit !== undefined) {
+    return rateLimit
+  }
+
   const transferToken = createCredential()
   const createdAt = Date.now()
   const expiresAt = createdAt + IDENTITY_TRANSFER_TTL_MS
@@ -53,6 +68,19 @@ export async function redeemIdentityTransfer(
   request: Request & RequestWithId,
   cloudflareEnvironment: CloudflareEnvironment
 ): Promise<Response> {
+  const rateLimit = await enforceRateLimit(
+    request,
+    cloudflareEnvironment.PLAYERS_DB,
+    {
+      scope: 'identity-transfer-redeem',
+      limit: 20,
+      windowMs: 15 * 60 * 1000
+    }
+  )
+  if (rateLimit !== undefined) {
+    return rateLimit
+  }
+
   const body = redeemIdentityTransferRequestSchema.safeParse(
     await request.json().catch(() => undefined)
   )

--- a/apps/worker/src/endpoints/webSocketTicket.ts
+++ b/apps/worker/src/endpoints/webSocketTicket.ts
@@ -1,10 +1,25 @@
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
 import { type BaseRequestWithProps } from '../types/itty'
+import { enforceRateLimit } from '../utils/rateLimit'
 
 export async function createWebSocketTicket(
-  request: BaseRequestWithProps,
+  request: Request & BaseRequestWithProps,
   cloudflareEnvironment: CloudflareEnvironment
 ): Promise<Response> {
+  const rateLimit = await enforceRateLimit(
+    request,
+    cloudflareEnvironment.PLAYERS_DB,
+    {
+      scope: 'websocket-ticket',
+      identifier: request.principal.playerId,
+      limit: 120,
+      windowMs: 60 * 1000
+    }
+  )
+  if (rateLimit !== undefined) {
+    return rateLimit
+  }
+
   const id = cloudflareEnvironment.WEB_SOCKET_DURABLE_OBJECT.idFromName(
     request.roomKey
   )

--- a/apps/worker/src/utils/rateLimit.ts
+++ b/apps/worker/src/utils/rateLimit.ts
@@ -1,0 +1,74 @@
+import { type RequestWithId } from '../types/itty'
+import { hashCredential } from './credentials'
+import { apiError } from './http'
+
+interface RateLimitOptions {
+  scope: string
+  limit: number
+  windowMs: number
+  identifier?: string
+}
+
+interface RateLimitBucketRow {
+  window_started_at: number
+  request_count: number
+}
+
+export async function enforceRateLimit(
+  request: Request & RequestWithId,
+  database: D1Database,
+  { scope, limit, windowMs, identifier }: RateLimitOptions
+): Promise<Response | undefined> {
+  const now = Date.now()
+  const windowCutoff = now - windowMs
+  const connectingIp = request.headers.get('CF-Connecting-IP')
+  if (
+    identifier === undefined &&
+    (connectingIp === null ||
+      connectingIp === '127.0.0.1' ||
+      connectingIp === '::1')
+  ) {
+    return
+  }
+
+  const clientIdentifier = identifier ?? connectingIp!
+  const bucketKey = await hashCredential(`${scope}:${clientIdentifier}`)
+  const bucket = await database
+    .prepare(
+      `INSERT INTO rate_limit_buckets
+        (bucket_key, window_started_at, request_count, updated_at)
+       VALUES (?, ?, 1, ?)
+       ON CONFLICT(bucket_key) DO UPDATE SET
+         window_started_at = CASE
+           WHEN rate_limit_buckets.window_started_at <= ?
+           THEN excluded.window_started_at
+           ELSE rate_limit_buckets.window_started_at
+         END,
+         request_count = CASE
+           WHEN rate_limit_buckets.window_started_at <= ? THEN 1
+           ELSE rate_limit_buckets.request_count + 1
+         END,
+         updated_at = excluded.updated_at
+       RETURNING window_started_at, request_count`
+    )
+    .bind(bucketKey, now, now, windowCutoff, windowCutoff)
+    .first<RateLimitBucketRow>()
+
+  if (bucket === null || bucket.request_count <= limit) {
+    return
+  }
+
+  const retryAfterSeconds = Math.max(
+    1,
+    Math.ceil((bucket.window_started_at + windowMs - now) / 1000)
+  )
+  const response = apiError({
+    status: 429,
+    code: 'RATE_LIMITED',
+    message: 'Too many requests. Please try again later.',
+    requestId: request.requestId,
+    retryable: true
+  })
+  response.headers.set('Retry-After', String(retryAfterSeconds))
+  return response
+}

--- a/apps/worker/test/worker.integration.test.ts
+++ b/apps/worker/test/worker.integration.test.ts
@@ -466,6 +466,34 @@ describe('identity recovery', () => {
     expect(sourceVerification.status).toBe(401)
     expect(recoveredVerification.status).toBe(204)
   })
+
+  it('rate-limits repeated recovery attempts by client address', async () => {
+    const recoveryPhrase =
+      'knucklebones-recovery-v1.bbbb.bbbb.bbbb.bbbb.bbbb.bbbb.bbbb.bbbb'
+    const makeAttempt = (clientAddress: string) =>
+      request('/v1/identity/recovery/redeem', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'CF-Connecting-IP': clientAddress
+        },
+        body: JSON.stringify({ recoveryPhrase })
+      })
+
+    for (let attempt = 0; attempt < 10; attempt++) {
+      expect((await makeAttempt('192.0.2.1')).status).toBe(410)
+    }
+
+    const limited = await makeAttempt('192.0.2.1')
+    expect(limited.status).toBe(429)
+    expect(limited.headers.get('Retry-After')).toMatch(/^\d+$/)
+    expect(apiErrorBodySchema.parse(await limited.json()).error).toMatchObject({
+      code: 'RATE_LIMITED',
+      retryable: true
+    })
+
+    expect((await makeAttempt('192.0.2.2')).status).toBe(410)
+  })
 })
 
 describe('atomic idempotent room mutations', () => {

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 
+test.describe.configure({ mode: 'serial' })
+
 interface StoredIdentity {
   displayName: string
   playerCredential: string
@@ -23,9 +25,11 @@ async function waitForHome(page: Page) {
 
 async function readIdentity(page: Page): Promise<StoredIdentity> {
   return await page.evaluate(() => ({
-    displayName: localStorage.displayName,
-    playerCredential: localStorage.playerCredential,
-    playerId: localStorage.playerId
+    displayName: localStorage.getItem('knucklebones.identity.v1.displayName')!,
+    playerCredential: localStorage.getItem(
+      'knucklebones.identity.v1.deviceCredential'
+    )!,
+    playerId: localStorage.getItem('knucklebones.identity.v1.playerId')!
   }))
 }
 
@@ -164,9 +168,15 @@ test('synchronizes a human game across independent browser identities', async ({
       (await firstColumns.count()) === 3 ? firstPlayer : secondPlayer
     const nextPlayer =
       currentPlayer === firstPlayer ? secondPlayer : firstPlayer
-    await currentPlayer.locator('div[role="button"]').first().click()
-
-    await expect(currentPlayer.locator('div[role="button"]')).toHaveCount(0)
+    const currentColumns = currentPlayer.locator('div[role="button"]')
+    await expect
+      .poll(async () => {
+        if ((await currentColumns.count()) === 3) {
+          await currentColumns.first().dispatchEvent('click')
+        }
+        return await currentColumns.count()
+      })
+      .toBe(0)
     await expect(nextPlayer.locator('div[role="button"]')).toHaveCount(3)
   } finally {
     await firstContext.close()


### PR DESCRIPTION
## Summary

- add atomic D1 rate-limit buckets for identity creation, transfer, recovery, and WebSocket tickets
- isolate limits by Cloudflare client address or authenticated player and return structured retryable 429 responses
- migrate legacy browser identity data into versioned storage keys without logging existing players out
- make repeated local browser runs deterministic while retaining production rate limits