### PR TITLE
feat(websocket): add authenticated room presence

### DIFF
--- a/apps/front/src/components/GameContext/useGameSetup.test.tsx
+++ b/apps/front/src/components/GameContext/useGameSetup.test.tsx
@@ -5,6 +5,7 @@ import {
   GameState,
   Player,
   toGameStateMessage,
+  toGamePresenceMessage,
   type IGameState
 } from '@knucklebones/common'
 import { act, renderHook, waitFor } from '@testing-library/react'
@@ -120,6 +121,23 @@ describe('useGameSetup', () => {
       rerender()
     })
     await waitFor(() => expect(initGame).toHaveBeenCalledTimes(2))
+  })
+
+  it('tracks valid room presence without replacing game state', async () => {
+    const { rerender, result } = renderHook(() => useGameSetup(), { wrapper })
+    emitMessage(toGameStateMessage(createGameState(1), roomKey), rerender)
+    await waitFor(() => expect(result.current?.revision).toBe(1))
+
+    emitMessage(toGamePresenceMessage(roomKey, playerId, true), rerender)
+    await waitFor(() =>
+      expect(result.current?.presenceByPlayerId[playerId]).toBe(true)
+    )
+    expect(result.current?.revision).toBe(1)
+
+    emitMessage(toGamePresenceMessage(roomKey, playerId, false), rerender)
+    await waitFor(() =>
+      expect(result.current?.presenceByPlayerId[playerId]).toBe(false)
+    )
   })
 
   it('rolls an optimistic move back after a network failure', async () => {

--- a/apps/front/src/components/GameContext/useGameSetup.ts
+++ b/apps/front/src/components/GameContext/useGameSetup.ts
@@ -4,6 +4,7 @@ import useWebSocketImport, { ReadyState } from 'react-use-websocket'
 import {
   AI_PLAYER_ID,
   compatibleGameStateMessageSchema,
+  gameServerEventSchema,
   GameState,
   getGameStateMessagePayload,
   type IGameState,
@@ -36,6 +37,9 @@ export function useGameSetup() {
   const [gameState, setGameState] = React.useState<IGameState | null>(null)
   const [isLoading, setIsLoading] = React.useState(true)
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
+  const [presenceByPlayerId, setPresenceByPlayerId] = React.useState<
+    Record<string, boolean>
+  >({})
   const roomKey = useRoomKey()
   const latestRevision = React.useRef({ roomKey, value: -1 })
   const state = useLocation().state as GameSettings | undefined
@@ -64,6 +68,23 @@ export function useGameSetup() {
 
   React.useEffect(() => {
     if (lastJsonMessage !== null) {
+      const serverEvent = gameServerEventSchema.safeParse(lastJsonMessage)
+      if (serverEvent.success && serverEvent.data.type !== 'game.state') {
+        if (
+          serverEvent.data.type === 'game.presence' &&
+          serverEvent.data.payload.roomKey === roomKey
+        ) {
+          const presenceEvent = serverEvent.data
+          setPresenceByPlayerId((presence) => ({
+            ...presence,
+            [presenceEvent.payload.playerId]: presenceEvent.payload.connected
+          }))
+        } else if (serverEvent.data.type === 'game.error') {
+          setErrorMessage(serverEvent.data.payload.message)
+        }
+        return
+      }
+
       const parsedGameState =
         compatibleGameStateMessageSchema.safeParse(lastJsonMessage)
 
@@ -105,6 +126,10 @@ export function useGameSetup() {
       setErrorMessage(null)
     }
   }, [lastJsonMessage, roomKey])
+
+  React.useEffect(() => {
+    setPresenceByPlayerId({})
+  }, [roomKey])
 
   React.useEffect(() => {
     if (readyState === ReadyState.OPEN) {
@@ -213,6 +238,7 @@ export function useGameSetup() {
     playerSide,
     winner,
     errorMessage,
+    presenceByPlayerId,
     sendPlay,
     clearErrorMessage,
     voteContinueBo,

--- a/apps/worker/src/durable-objects/WebSocketDurableObject.ts
+++ b/apps/worker/src/durable-objects/WebSocketDurableObject.ts
@@ -1,8 +1,12 @@
 import { Toucan } from 'toucan-js'
 import {
+  credentialIdSchema,
   credentialSchema,
   gameServerEventSchema,
   playerIdSchema,
+  PROTOCOL_VERSION,
+  roomKeySchema,
+  toGamePresenceMessage,
   type WebSocketTicket
 } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
@@ -14,6 +18,9 @@ const WEB_SOCKET_TICKETS_STORAGE_KEY = 'websocket-tickets'
 
 interface PendingWebSocketTicket {
   playerId: string
+  credentialId: string
+  roomKey: string
+  protocolVersion: typeof PROTOCOL_VERSION
   expiresAt: number
 }
 
@@ -28,6 +35,9 @@ export function removeExpiredWebSocketTickets(
       ([ticketHash, ticket]) =>
         credentialSchema.safeParse(ticketHash).success &&
         playerIdSchema.safeParse(ticket.playerId).success &&
+        credentialIdSchema.safeParse(ticket.credentialId).success &&
+        roomKeySchema.safeParse(ticket.roomKey).success &&
+        ticket.protocolVersion === PROTOCOL_VERSION &&
         Number.isInteger(ticket.expiresAt) &&
         ticket.expiresAt > now
     )
@@ -36,6 +46,11 @@ export function removeExpiredWebSocketTickets(
 
 interface WebSocketSession {
   playerId: string
+  credentialId: string
+  roomKey: string
+  connectionId: string
+  protocolVersion: typeof PROTOCOL_VERSION
+  role: 'pending' | 'player' | 'spectator'
   connectedAt: number
 }
 
@@ -65,8 +80,15 @@ export class WebSocketDurableObject {
       switch (url.pathname) {
         case '/ticket': {
           const playerId = request.headers.get('X-Player-Id')
+          const credentialId = request.headers.get('X-Credential-Id')
+          const roomKey = request.headers.get('X-Room-Key')
 
-          if (request.method !== 'POST' || playerId === null) {
+          if (
+            request.method !== 'POST' ||
+            playerId === null ||
+            credentialId === null ||
+            roomKey === null
+          ) {
             return apiError({
               status: 400,
               code: 'INVALID_WEBSOCKET_TICKET_REQUEST',
@@ -75,7 +97,7 @@ export class WebSocketDurableObject {
             })
           }
 
-          return await this.createTicket(playerId)
+          return await this.createTicket(playerId, credentialId, roomKey)
         }
         case '/websocket': {
           if (request.headers.get('Upgrade') !== 'websocket') {
@@ -117,6 +139,12 @@ export class WebSocketDurableObject {
             })
           }
 
+          if (event.data.type === 'game.state') {
+            this.updateSessionRoles(
+              event.data.payload.gameState.playerOne.id,
+              event.data.payload.gameState.playerTwo.id
+            )
+          }
           this.broadcast(JSON.stringify(event.data))
           return new Response(null, { status: 200 })
         }
@@ -142,8 +170,18 @@ export class WebSocketDurableObject {
   }
 
   async handleSession(webSocket: WebSocket, session: WebSocketSession) {
+    const wasConnected = this.hasOpenSession(session.playerId)
     this.state.acceptWebSocket(webSocket, [`player:${session.playerId}`])
     webSocket.serializeAttachment(session)
+    this.sendPresenceSnapshot(webSocket, session.roomKey, webSocket)
+
+    if (!wasConnected) {
+      this.broadcast(
+        JSON.stringify(
+          toGamePresenceMessage(session.roomKey, session.playerId, true)
+        )
+      )
+    }
   }
 
   async webSocketMessage(webSocket: WebSocket) {
@@ -156,6 +194,18 @@ export class WebSocketDurableObject {
     reason: string,
     wasClean: boolean
   ) {
+    const session = this.readSession(webSocket)
+    if (
+      session !== undefined &&
+      !this.hasOpenSession(session.playerId, webSocket)
+    ) {
+      this.broadcast(
+        JSON.stringify(
+          toGamePresenceMessage(session.roomKey, session.playerId, false)
+        )
+      )
+    }
+
     if (!wasClean) {
       this.sentry.captureMessage(`${code} - ${reason}`, 'error')
     }
@@ -175,8 +225,16 @@ export class WebSocketDurableObject {
     })
   }
 
-  private async createTicket(playerId: string): Promise<Response> {
-    if (!playerIdSchema.safeParse(playerId).success) {
+  private async createTicket(
+    playerId: string,
+    credentialId: string,
+    roomKey: string
+  ): Promise<Response> {
+    if (
+      !playerIdSchema.safeParse(playerId).success ||
+      !credentialIdSchema.safeParse(credentialId).success ||
+      !roomKeySchema.safeParse(roomKey).success
+    ) {
       throw new Error('Cannot issue a WebSocket ticket for an invalid player.')
     }
 
@@ -190,7 +248,13 @@ export class WebSocketDurableObject {
         WEB_SOCKET_TICKETS_STORAGE_KEY
       )
       const activeTickets = removeExpiredWebSocketTickets(tickets ?? {}, now)
-      activeTickets[ticketHash] = { playerId, expiresAt }
+      activeTickets[ticketHash] = {
+        playerId,
+        credentialId,
+        roomKey,
+        protocolVersion: PROTOCOL_VERSION,
+        expiresAt
+      }
       await transaction.put(WEB_SOCKET_TICKETS_STORAGE_KEY, activeTickets)
     })
 
@@ -230,7 +294,85 @@ export class WebSocketDurableObject {
         return undefined
       }
 
-      return { playerId: pendingTicket.playerId, connectedAt: now }
+      return {
+        playerId: pendingTicket.playerId,
+        credentialId: pendingTicket.credentialId,
+        roomKey: pendingTicket.roomKey,
+        connectionId: crypto.randomUUID(),
+        protocolVersion: pendingTicket.protocolVersion,
+        role: 'pending',
+        connectedAt: now
+      }
+    })
+  }
+
+  private hasOpenSession(playerId: string, excluded?: WebSocket): boolean {
+    return this.state
+      .getWebSockets(`player:${playerId}`)
+      .some(
+        (webSocket) =>
+          webSocket !== excluded && webSocket.readyState === WebSocket.OPEN
+      )
+  }
+
+  private readSession(webSocket: WebSocket): WebSocketSession | undefined {
+    const session = webSocket.deserializeAttachment() as
+      Partial<WebSocketSession> | undefined
+
+    if (
+      session === undefined ||
+      !playerIdSchema.safeParse(session.playerId).success ||
+      !credentialIdSchema.safeParse(session.credentialId).success ||
+      !roomKeySchema.safeParse(session.roomKey).success ||
+      !credentialIdSchema.safeParse(session.connectionId).success ||
+      session.protocolVersion !== PROTOCOL_VERSION ||
+      !['pending', 'player', 'spectator'].includes(session.role ?? '') ||
+      !Number.isInteger(session.connectedAt)
+    ) {
+      return undefined
+    }
+
+    return session as WebSocketSession
+  }
+
+  private sendPresenceSnapshot(
+    webSocket: WebSocket,
+    roomKey: string,
+    excluded: WebSocket
+  ): void {
+    const connectedPlayerIds = new Set<string>()
+    this.state.getWebSockets().forEach((connectedWebSocket) => {
+      if (
+        connectedWebSocket === excluded ||
+        connectedWebSocket.readyState !== WebSocket.OPEN
+      ) {
+        return
+      }
+      const session = this.readSession(connectedWebSocket)
+      if (session !== undefined) {
+        connectedPlayerIds.add(session.playerId)
+      }
+    })
+
+    connectedPlayerIds.forEach((playerId) => {
+      webSocket.send(
+        JSON.stringify(toGamePresenceMessage(roomKey, playerId, true))
+      )
+    })
+  }
+
+  private updateSessionRoles(playerOneId: string, playerTwoId: string): void {
+    this.state.getWebSockets().forEach((webSocket) => {
+      const session = this.readSession(webSocket)
+      if (session === undefined) {
+        return
+      }
+
+      session.role =
+        session.playerId === playerOneId || session.playerId === playerTwoId
+          ? 'player'
+          : 'spectator'
+      webSocket.serializeAttachment(session)
     })
   }
 }

--- a/apps/worker/src/endpoints/webSocketTicket.ts
+++ b/apps/worker/src/endpoints/webSocketTicket.ts
@@ -28,7 +28,9 @@ export async function createWebSocketTicket(
   return await webSocketStore.fetch('https://dummy-url/ticket', {
     method: 'POST',
     headers: {
-      'X-Player-Id': request.playerId,
+      'X-Player-Id': request.principal.playerId,
+      'X-Credential-Id': request.principal.credentialId,
+      'X-Room-Key': request.roomKey,
       'X-Request-Id': request.requestId
     }
   })

--- a/apps/worker/test/webSocketTickets.test.ts
+++ b/apps/worker/test/webSocketTickets.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from 'vitest'
+import { PROTOCOL_VERSION } from '@knucklebones/common'
 import { removeExpiredWebSocketTickets } from '../src/durable-objects/WebSocketDurableObject'
+
+const credentialId = '44444444-4444-4444-8444-444444444444'
+const roomKey = '11111111-1111-4111-8111-111111111111'
+
+function ticket(playerId: string, expiresAt: number) {
+  return {
+    playerId,
+    credentialId,
+    roomKey,
+    protocolVersion: PROTOCOL_VERSION,
+    expiresAt
+  }
+}
 
 describe('removeExpiredWebSocketTickets', () => {
   it('removes tickets at and before their expiry time', () => {
@@ -11,14 +25,14 @@ describe('removeExpiredWebSocketTickets', () => {
     expect(
       removeExpiredWebSocketTickets(
         {
-          [expiredHash]: { playerId, expiresAt: 99 },
-          [boundaryHash]: { playerId, expiresAt: 100 },
-          [activeHash]: { playerId, expiresAt: 101 }
+          [expiredHash]: ticket(playerId, 99),
+          [boundaryHash]: ticket(playerId, 100),
+          [activeHash]: ticket(playerId, 101)
         },
         100
       )
     ).toEqual({
-      [activeHash]: { playerId, expiresAt: 101 }
+      [activeHash]: ticket(playerId, 101)
     })
   })
 
@@ -28,6 +42,9 @@ describe('removeExpiredWebSocketTickets', () => {
         {
           malformed: {
             playerId: 'not-a-player-id',
+            credentialId,
+            roomKey,
+            protocolVersion: PROTOCOL_VERSION,
             expiresAt: 101
           }
         },

--- a/packages/common/src/schemas/gameStateMessage.ts
+++ b/packages/common/src/schemas/gameStateMessage.ts
@@ -108,3 +108,17 @@ export function toGameStateMessage(
     payload: { roomKey, gameState }
   }
 }
+
+export function toGamePresenceMessage(
+  roomKey: string,
+  playerId: string,
+  connected: boolean,
+  requestId?: string
+): GamePresenceEvent {
+  return {
+    version: PROTOCOL_VERSION,
+    type: 'game.presence',
+    ...(requestId !== undefined && { requestId }),
+    payload: { roomKey, playerId, connected }
+  }
+}

--- a/tests/e2e/websocket.spec.ts
+++ b/tests/e2e/websocket.spec.ts
@@ -1,6 +1,59 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type APIRequestContext } from '@playwright/test'
 
 const workerUrl = 'http://localhost:8787'
+
+interface PlayerCredentials {
+  playerId: string
+  credential: string
+}
+
+interface GamePresenceEvent {
+  version: 1
+  type: 'game.presence'
+  payload: {
+    roomKey: string
+    playerId: string
+    connected: boolean
+  }
+}
+
+async function createPlayer(
+  request: APIRequestContext
+): Promise<PlayerCredentials> {
+  return (await (
+    await request.post(`${workerUrl}/players`)
+  ).json()) as PlayerCredentials
+}
+
+async function issueTicket(
+  request: APIRequestContext,
+  roomKey: string,
+  player: PlayerCredentials
+): Promise<string> {
+  const response = await request.post(
+    `${workerUrl}/${roomKey}/${player.playerId}/websocket-ticket`,
+    { headers: { Authorization: `Bearer ${player.credential}` } }
+  )
+  expect(response.status()).toBe(201)
+  return ((await response.json()) as { ticket: string }).ticket
+}
+
+async function openSocket(roomKey: string, ticket: string): Promise<WebSocket> {
+  return await new Promise((resolve, reject) => {
+    const socket = new WebSocket(
+      `${workerUrl.replace('http', 'ws')}/${roomKey}/websocket?ticket=${ticket}`
+    )
+    socket.addEventListener('open', () => resolve(socket), { once: true })
+    socket.addEventListener('error', reject, { once: true })
+  })
+}
+
+async function closeSocket(socket: WebSocket): Promise<void> {
+  await new Promise<void>((resolve) => {
+    socket.addEventListener('close', () => resolve(), { once: true })
+    socket.close()
+  })
+}
 
 test('WebSocket tickets are authenticated, one-time, and reject client messages', async ({
   request
@@ -22,6 +75,15 @@ test('WebSocket tickets are authenticated, one-time, and reject client messages'
   const { ticket } = (await ticketResponse.json()) as { ticket: string }
   expect(ticket).toMatch(/^[0-9a-f]{64}$/)
   const socketUrl = `${workerUrl.replace('http', 'ws')}/${roomKey}/websocket?ticket=${ticket}`
+  const wrongRoomUrl = `${workerUrl.replace('http', 'ws')}/${crypto.randomUUID()}/websocket?ticket=${ticket}`
+
+  await expect(
+    new Promise<void>((resolve, reject) => {
+      const wrongRoomSocket = new WebSocket(wrongRoomUrl)
+      wrongRoomSocket.addEventListener('open', () => resolve(), { once: true })
+      wrongRoomSocket.addEventListener('error', reject, { once: true })
+    })
+  ).rejects.toBeDefined()
 
   const closeCode = await new Promise<number>((resolve, reject) => {
     const socket = new WebSocket(socketUrl)
@@ -41,3 +103,59 @@ test('WebSocket tickets are authenticated, one-time, and reject client messages'
     })
   ).rejects.toBeDefined()
 })
+
+test('presence changes only for the first and final socket of an identity', async ({
+  request
+}) => {
+  test.setTimeout(60_000)
+  const observer = await createPlayer(request)
+  const player = await createPlayer(request)
+  const roomKey = crypto.randomUUID()
+  const observerSocket = await openSocket(
+    roomKey,
+    await issueTicket(request, roomKey, observer)
+  )
+  const playerPresence: GamePresenceEvent[] = []
+  observerSocket.addEventListener('message', ({ data }) => {
+    const event = parsePresenceEvent(String(data))
+    if (event?.payload.playerId === player.playerId) {
+      playerPresence.push(event)
+    }
+  })
+
+  const firstPlayerSocket = await openSocket(
+    roomKey,
+    await issueTicket(request, roomKey, player)
+  )
+  await expect.poll(() => playerPresence.length).toBe(1)
+  expect(playerPresence[0].payload.connected).toBe(true)
+
+  const secondPlayerSocket = await openSocket(
+    roomKey,
+    await issueTicket(request, roomKey, player)
+  )
+  await closeSocket(firstPlayerSocket)
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  expect(playerPresence).toHaveLength(1)
+
+  await closeSocket(secondPlayerSocket)
+  await expect.poll(() => playerPresence.length).toBe(2)
+  expect(playerPresence[1].payload.connected).toBe(false)
+
+  observerSocket.close()
+})
+
+function parsePresenceEvent(message: string): GamePresenceEvent | undefined {
+  const event = JSON.parse(message) as Partial<GamePresenceEvent>
+  if (
+    event.version !== 1 ||
+    event.type !== 'game.presence' ||
+    typeof event.payload?.roomKey !== 'string' ||
+    typeof event.payload.playerId !== 'string' ||
+    typeof event.payload.connected !== 'boolean'
+  ) {
+    return undefined
+  }
+
+  return event as GamePresenceEvent
+}


### PR DESCRIPTION
## Summary

- scope single-use WebSocket tickets to a room, credential, and protocol version
- persist authenticated connection IDs and player/spectator roles in hibernation attachments
- broadcast presence only when an identity's first socket opens or final socket closes
- validate presence events in the frontend and reject cross-room ticket use