### PR TITLE
feat(worker): adjudicate ranked disconnects

### DIFF
--- a/apps/front/src/components/Game.tsx
+++ b/apps/front/src/components/Game.tsx
@@ -8,6 +8,7 @@ import { Loading } from './Loading'
 import { OutcomeHistory } from './OutcomeHistory'
 import { PlayerOneBoard, PlayerTwoBoard } from './PlayerBoard'
 import { QRCodeModal } from './QRCode'
+import { ReconnectNotice } from './ReconnectNotice'
 import { SideBarActions } from './SideBar'
 import { WarningToast } from './WarningToast'
 
@@ -35,6 +36,7 @@ export function Game() {
         {isOnMobile && gameOutcome}
       </SideBarActions>
       <div ref={gameRef} className='flex flex-col items-center justify-around'>
+        <ReconnectNotice />
         <PlayerTwoBoard />
         {!isOnMobile && gameOutcome}
         <PlayerOneBoard />

--- a/apps/front/src/components/GameContext/useGameSetup.test.tsx
+++ b/apps/front/src/components/GameContext/useGameSetup.test.tsx
@@ -6,6 +6,7 @@ import {
   Player,
   toGameStateMessage,
   toGamePresenceMessage,
+  toGameReconnectDeadlineMessage,
   type IGameState
 } from '@knucklebones/common'
 import { act, renderHook, waitFor } from '@testing-library/react'
@@ -137,6 +138,58 @@ describe('useGameSetup', () => {
     emitMessage(toGamePresenceMessage(roomKey, playerId, false), rerender)
     await waitFor(() =>
       expect(result.current?.presenceByPlayerId[playerId]).toBe(false)
+    )
+  })
+
+  it('tracks and clears reconnect deadlines', async () => {
+    const { rerender, result } = renderHook(() => useGameSetup(), { wrapper })
+    emitMessage(toGameStateMessage(createGameState(1), roomKey), rerender)
+    await waitFor(() => expect(result.current?.revision).toBe(1))
+
+    emitMessage(
+      toGameReconnectDeadlineMessage(roomKey, playerId, 123_456),
+      rerender
+    )
+    await waitFor(() =>
+      expect(result.current?.reconnectDeadlineByPlayerId[playerId]).toBe(
+        123_456
+      )
+    )
+
+    emitMessage(toGameReconnectDeadlineMessage(roomKey, playerId, 0), rerender)
+    await waitFor(() =>
+      expect(
+        result.current?.reconnectDeadlineByPlayerId[playerId]
+      ).toBeUndefined()
+    )
+  })
+
+  it('clears reconnect deadlines when the game ends', async () => {
+    const { rerender, result } = renderHook(() => useGameSetup(), { wrapper })
+    emitMessage(toGameStateMessage(createGameState(1), roomKey), rerender)
+    emitMessage(
+      toGameReconnectDeadlineMessage(roomKey, playerId, 123_456),
+      rerender
+    )
+    await waitFor(() =>
+      expect(result.current?.reconnectDeadlineByPlayerId[playerId]).toBe(
+        123_456
+      )
+    )
+
+    emitMessage(
+      toGameStateMessage(
+        {
+          ...createGameState(2),
+          outcome: 'game-ended',
+          finishReason: 'no-contest'
+        },
+        roomKey
+      ),
+      rerender
+    )
+    await waitFor(() =>
+      expect(result.current?.reconnectDeadlineByPlayerId).toEqual({})
     )
   })
 

--- a/apps/front/src/components/GameContext/useGameSetup.ts
+++ b/apps/front/src/components/GameContext/useGameSetup.ts
@@ -40,6 +40,8 @@ export function useGameSetup() {
   const [presenceByPlayerId, setPresenceByPlayerId] = React.useState<
     Record<string, boolean>
   >({})
+  const [reconnectDeadlineByPlayerId, setReconnectDeadlineByPlayerId] =
+    React.useState<Record<string, number>>({})
   const roomKey = useRoomKey()
   const latestRevision = React.useRef({ roomKey, value: -1 })
   const state = useLocation().state as GameSettings | undefined
@@ -79,6 +81,21 @@ export function useGameSetup() {
             ...presence,
             [presenceEvent.payload.playerId]: presenceEvent.payload.connected
           }))
+        } else if (
+          serverEvent.data.type === 'game.reconnect-deadline' &&
+          serverEvent.data.payload.roomKey === roomKey
+        ) {
+          const deadlineEvent = serverEvent.data
+          setReconnectDeadlineByPlayerId((deadlines) => {
+            const nextDeadlines = { ...deadlines }
+            if (deadlineEvent.payload.expiresAt === 0) {
+              delete nextDeadlines[deadlineEvent.payload.playerId]
+            } else {
+              nextDeadlines[deadlineEvent.payload.playerId] =
+                deadlineEvent.payload.expiresAt
+            }
+            return nextDeadlines
+          })
         } else if (serverEvent.data.type === 'game.error') {
           setErrorMessage(serverEvent.data.payload.message)
         }
@@ -122,6 +139,9 @@ export function useGameSetup() {
       }
 
       setGameState(nextGameState)
+      if (nextGameState.outcome !== 'ongoing') {
+        setReconnectDeadlineByPlayerId({})
+      }
       setIsLoading(false)
       setErrorMessage(null)
     }
@@ -129,6 +149,7 @@ export function useGameSetup() {
 
   React.useEffect(() => {
     setPresenceByPlayerId({})
+    setReconnectDeadlineByPlayerId({})
   }, [roomKey])
 
   React.useEffect(() => {
@@ -239,6 +260,7 @@ export function useGameSetup() {
     winner,
     errorMessage,
     presenceByPlayerId,
+    reconnectDeadlineByPlayerId,
     sendPlay,
     clearErrorMessage,
     voteContinueBo,

--- a/apps/front/src/components/ReconnectNotice.tsx
+++ b/apps/front/src/components/ReconnectNotice.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useGame } from './GameContext'
+
+export function ReconnectNotice() {
+  const { t } = useTranslation()
+  const { reconnectDeadlineByPlayerId, playerOne, playerTwo } = useGame()
+  const [now, setNow] = React.useState(Date.now())
+  const activeDeadline = Object.entries(reconnectDeadlineByPlayerId).sort(
+    ([, left], [, right]) => left - right
+  )[0]
+  const activeDeadlineExpiresAt = activeDeadline?.[1]
+
+  React.useEffect(() => {
+    if (activeDeadlineExpiresAt === undefined) {
+      return
+    }
+
+    const interval = setInterval(() => setNow(Date.now()), 1_000)
+    return () => clearInterval(interval)
+  }, [activeDeadlineExpiresAt])
+
+  if (activeDeadline === undefined) {
+    return null
+  }
+
+  const [disconnectedPlayerId, expiresAt] = activeDeadline
+  const disconnectedPlayer =
+    playerOne.id === disconnectedPlayerId ? playerOne : playerTwo
+  const seconds = Math.max(0, Math.ceil((expiresAt - now) / 1_000))
+
+  return (
+    <div
+      role='status'
+      className='fixed top-4 z-10 rounded-lg bg-amber-100 px-4 py-3 text-amber-900 shadow dark:bg-amber-900 dark:text-amber-100'
+    >
+      {t('reconnect.deadline', {
+        player: disconnectedPlayer.displayName ?? disconnectedPlayer.id,
+        seconds
+      })}
+    </div>
+  )
+}

--- a/apps/front/src/translations/resources/en.json
+++ b/apps/front/src/translations/resources/en.json
@@ -78,6 +78,9 @@
     }
   },
   "loading": "Waiting for game to start",
+  "reconnect": {
+    "deadline": "{{player}} disconnected. They have {{seconds}} seconds to reconnect."
+  },
   "identity": {
     "loading": "Creating your player identity…",
     "error": "We couldn't create your player identity.",

--- a/apps/front/src/translations/resources/fr.json
+++ b/apps/front/src/translations/resources/fr.json
@@ -79,6 +79,9 @@
     }
   },
   "loading": "En attente du début de la partie",
+  "reconnect": {
+    "deadline": "{{player}} s'est déconnecté. Il lui reste {{seconds}} secondes pour se reconnecter."
+  },
   "identity": {
     "loading": "Création de votre identité de joueur…",
     "error": "Impossible de créer votre identité de joueur.",

--- a/apps/front/src/translations/resources/zh-tw.json
+++ b/apps/front/src/translations/resources/zh-tw.json
@@ -78,6 +78,9 @@
     }
   },
   "loading": "等待遊戲開始",
+  "reconnect": {
+    "deadline": "{{player}} 已斷線。還有 {{seconds}} 秒可以重新連線。"
+  },
   "identity": {
     "loading": "正在建立您的玩家身分…",
     "error": "無法建立您的玩家身分。",

--- a/apps/worker/src/durable-objects/GameStateDurableObject.ts
+++ b/apps/worker/src/durable-objects/GameStateDurableObject.ts
@@ -17,9 +17,13 @@ import {
   type PlayGameResult,
   playGameCommandSchema,
   playGameResultSchema,
+  playerIdSchema,
+  type PresenceUpdateResult,
   type RematchGameResult,
   rematchGameCommandSchema,
   rematchGameResultSchema,
+  roomKeySchema,
+  toGameStateMessage,
   type UpdateDisplayNameResult,
   updateDisplayNameCommandSchema,
   updateDisplayNameResultSchema
@@ -38,6 +42,12 @@ type ProcessedMutations = Record<string, ProcessedMutation>
 
 const PROCESSED_MUTATION_TTL_MS = 15 * 60 * 1000
 const MAX_PROCESSED_MUTATIONS = 200
+const DEFAULT_DISCONNECT_GRACE_MS = 60_000
+
+interface DisconnectPolicy {
+  roomKey: string
+  gracePeriodMs: number
+}
 
 export class GameStateDurableObject extends createDurable({
   autoPersist: true
@@ -45,6 +55,10 @@ export class GameStateDurableObject extends createDurable({
   lobby: ILobby
   gameState?: IGameState
   processedMutations: ProcessedMutations
+  disconnectPolicy?: DisconnectPolicy
+  connectedPlayers: Record<string, boolean>
+  reconnectDeadlines: Record<string, number>
+  pendingDisconnectBroadcast?: IGameState
 
   constructor(
     state: DurableObjectState,
@@ -53,6 +67,134 @@ export class GameStateDurableObject extends createDurable({
     super(state, cloudflareEnvironment)
     this.lobby = new Lobby().toJson()
     this.processedMutations = {}
+    this.connectedPlayers = {}
+    this.reconnectDeadlines = {}
+  }
+
+  configureDisconnectPolicy(
+    roomKey: string,
+    gracePeriodMs = DEFAULT_DISCONNECT_GRACE_MS
+  ): void {
+    this.disconnectPolicy = {
+      roomKey: roomKeySchema.parse(roomKey),
+      gracePeriodMs: Number.isInteger(gracePeriodMs)
+        ? Math.min(Math.max(gracePeriodMs, 1), 5 * 60_000)
+        : DEFAULT_DISCONNECT_GRACE_MS
+    }
+  }
+
+  async updatePresence(
+    playerId: string,
+    connected: boolean,
+    observedAt = Date.now()
+  ): Promise<PresenceUpdateResult> {
+    const parsedPlayerId = playerIdSchema.parse(playerId)
+    if (typeof connected !== 'boolean' || !Number.isInteger(observedAt)) {
+      throw new Error('Invalid presence update.')
+    }
+    if (this.disconnectPolicy === undefined) {
+      return { status: 'disabled' }
+    }
+
+    const gameState = this.readPlayerGameState(parsedPlayerId)
+    if (gameState === undefined || gameState.outcome !== 'ongoing') {
+      return { status: 'ignored' }
+    }
+
+    if (connected) {
+      const hadDeadline = this.reconnectDeadlines[parsedPlayerId] !== undefined
+      const changed = this.connectedPlayers[parsedPlayerId] !== true
+      this.connectedPlayers[parsedPlayerId] = true
+      delete this.reconnectDeadlines[parsedPlayerId]
+
+      const adjudication = this.adjudicateDisconnects(observedAt)
+      await this.scheduleDisconnectAlarm()
+      if (adjudication.status === 'adjudicated') {
+        return adjudication
+      }
+
+      return changed || hadDeadline
+        ? {
+            status: 'updated',
+            playerId: parsedPlayerId,
+            connected: true,
+            ...(hadDeadline && { reconnectDeadline: 0 })
+          }
+        : { status: 'unchanged' }
+    }
+
+    if (
+      this.connectedPlayers[parsedPlayerId] === false &&
+      this.reconnectDeadlines[parsedPlayerId] !== undefined
+    ) {
+      return { status: 'unchanged' }
+    }
+
+    this.connectedPlayers[parsedPlayerId] = false
+    const reconnectDeadline = observedAt + this.disconnectPolicy.gracePeriodMs
+    this.reconnectDeadlines[parsedPlayerId] = reconnectDeadline
+    await this.scheduleDisconnectAlarm()
+
+    return {
+      status: 'updated',
+      playerId: parsedPlayerId,
+      connected: false,
+      reconnectDeadline
+    }
+  }
+
+  adjudicateDisconnects(now = Date.now()): PresenceUpdateResult {
+    if (this.disconnectPolicy === undefined || this.gameState === undefined) {
+      return { status: 'disabled' }
+    }
+
+    const gameState = GameState.fromJson(gameStateSchema.parse(this.gameState))
+    if (gameState.outcome !== 'ongoing') {
+      this.reconnectDeadlines = {}
+      return { status: 'unchanged' }
+    }
+
+    const players = [gameState.playerOne.id, gameState.playerTwo.id]
+    const expiredPlayers = players.filter(
+      (playerId) => (this.reconnectDeadlines[playerId] ?? Infinity) <= now
+    )
+
+    if (expiredPlayers.length === 2) {
+      gameState.finishAsNoContest()
+    } else if (expiredPlayers.length === 1) {
+      const disconnectedPlayerId = expiredPlayers[0]
+      const opponentId = players.find(
+        (playerId) => playerId !== disconnectedPlayerId
+      )!
+      if (this.connectedPlayers[opponentId] !== true) {
+        return { status: 'unchanged' }
+      }
+      gameState.finishByForfeit(disconnectedPlayerId)
+    } else {
+      return { status: 'unchanged' }
+    }
+
+    this.reconnectDeadlines = {}
+    return {
+      status: 'adjudicated',
+      gameState: this.commitGameState(gameState)
+    }
+  }
+
+  async alarm(): Promise<void> {
+    await this.loadFromStorage()
+    const result = this.adjudicateDisconnects()
+    if (result.status === 'adjudicated') {
+      this.pendingDisconnectBroadcast = result.gameState
+    }
+    await this.scheduleDisconnectAlarm()
+    await this.persist()
+
+    if (this.pendingDisconnectBroadcast !== undefined) {
+      await this.broadcastAlarmResult(this.pendingDisconnectBroadcast)
+      this.pendingDisconnectBroadcast = undefined
+      await this.persist()
+    }
   }
 
   initializeGame({
@@ -261,6 +403,55 @@ export class GameStateDurableObject extends createDurable({
     return {
       status: 'updated',
       gameState: this.commitGameState(gameState)
+    }
+  }
+
+  private readPlayerGameState(playerId: string): GameState | undefined {
+    if (this.gameState === undefined) {
+      return
+    }
+
+    const gameState = GameState.fromJson(gameStateSchema.parse(this.gameState))
+    if (
+      gameState.playerOne.id !== playerId &&
+      gameState.playerTwo.id !== playerId
+    ) {
+      return
+    }
+
+    return gameState
+  }
+
+  private async scheduleDisconnectAlarm(): Promise<void> {
+    const deadlines = Object.values(this.reconnectDeadlines)
+    if (deadlines.length === 0) {
+      await this.deleteAlarm()
+      return
+    }
+
+    await this.setAlarm(Math.min(...deadlines))
+  }
+
+  private async broadcastAlarmResult(gameState: IGameState): Promise<void> {
+    const roomKey = this.disconnectPolicy?.roomKey
+    if (roomKey === undefined) {
+      return
+    }
+
+    const environment = (
+      this.state as DurableObjectState & { env: CloudflareEnvironment }
+    ).env
+    const id = environment.WEB_SOCKET_DURABLE_OBJECT.idFromName(roomKey)
+    const webSocketStore = environment.WEB_SOCKET_DURABLE_OBJECT.get(id)
+    const requestId = crypto.randomUUID()
+    const response = await webSocketStore.fetch('https://dummy-url/broadcast', {
+      method: 'POST',
+      headers: { 'X-Request-Id': requestId },
+      body: JSON.stringify(toGameStateMessage(gameState, roomKey, requestId))
+    })
+
+    if (!response.ok) {
+      throw new Error('The WebSocket room rejected a disconnect outcome.')
     }
   }
 

--- a/apps/worker/src/durable-objects/WebSocketDurableObject.ts
+++ b/apps/worker/src/durable-objects/WebSocketDurableObject.ts
@@ -4,9 +4,12 @@ import {
   credentialSchema,
   gameServerEventSchema,
   playerIdSchema,
+  presenceUpdateResultSchema,
   PROTOCOL_VERSION,
   roomKeySchema,
+  toGameReconnectDeadlineMessage,
   toGamePresenceMessage,
+  toGameStateMessage,
   type WebSocketTicket
 } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
@@ -181,6 +184,7 @@ export class WebSocketDurableObject {
           toGamePresenceMessage(session.roomKey, session.playerId, true)
         )
       )
+      await this.reportPresence(session, true)
     }
   }
 
@@ -204,6 +208,7 @@ export class WebSocketDurableObject {
           toGamePresenceMessage(session.roomKey, session.playerId, false)
         )
       )
+      await this.reportPresence(session, false)
     }
 
     if (!wasClean) {
@@ -374,5 +379,46 @@ export class WebSocketDurableObject {
           : 'spectator'
       webSocket.serializeAttachment(session)
     })
+  }
+
+  private async reportPresence(
+    session: WebSocketSession,
+    connected: boolean
+  ): Promise<void> {
+    const id = this.cloudflareEnvironment.GAME_STATE_DURABLE_OBJECT.idFromName(
+      session.roomKey
+    )
+    const gameStateStore =
+      this.cloudflareEnvironment.GAME_STATE_DURABLE_OBJECT.get(id)
+    const response = await gameStateStore.fetch(
+      'https://itty-durable/do/call/updatePresence',
+      {
+        headers: {
+          'do-name': session.roomKey,
+          'do-content': JSON.stringify([session.playerId, connected])
+        }
+      }
+    )
+    if (!response.ok) {
+      throw new Error('The game room rejected a presence update.')
+    }
+
+    const result = presenceUpdateResultSchema.parse(await response.json())
+
+    if (result.status === 'updated' && result.reconnectDeadline !== undefined) {
+      this.broadcast(
+        JSON.stringify(
+          toGameReconnectDeadlineMessage(
+            session.roomKey,
+            session.playerId,
+            result.reconnectDeadline
+          )
+        )
+      )
+    } else if (result.status === 'adjudicated') {
+      this.broadcast(
+        JSON.stringify(toGameStateMessage(result.gameState, session.roomKey))
+      )
+    }
   }
 }

--- a/apps/worker/test/worker.integration.test.ts
+++ b/apps/worker/test/worker.integration.test.ts
@@ -8,6 +8,7 @@ import {
   matchmakingStatusSchema,
   playerCredentialsSchema,
   playerIdentityBootstrapSchema,
+  type PresenceUpdateResult,
   rankedProfileSchema,
   webSocketTicketSchema,
   type PlayerCredentials
@@ -534,6 +535,122 @@ describe('atomic idempotent room mutations', () => {
     await expect(conflict.json()).resolves.toMatchObject({
       error: { code: 'IDEMPOTENCY_KEY_REUSED' }
     })
+  })
+})
+
+describe('ranked disconnect adjudication', () => {
+  async function createActiveRoom() {
+    const playerOne = await createPlayer()
+    const playerTwo = await createPlayer()
+    const roomKey = crypto.randomUUID()
+
+    for (const player of [playerOne, playerTwo]) {
+      const response = await request(`/${roomKey}/${player.playerId}/init`, {
+        method: 'POST',
+        headers: {
+          ...authorization(player),
+          'Idempotency-Key': crypto.randomUUID()
+        }
+      })
+      expect(response.status).toBe(200)
+    }
+
+    const environment = await server.getWorker().getEnv()
+    const durableObjectId =
+      environment.GAME_STATE_DURABLE_OBJECT.idFromName(roomKey)
+    const game = environment.GAME_STATE_DURABLE_OBJECT.get(durableObjectId)
+    const callGame = async <T>(method: string, args: unknown[]): Promise<T> => {
+      const response = await game.fetch(
+        `https://itty-durable/do/call/${method}`,
+        {
+          headers: {
+            'do-name': roomKey,
+            'do-content': JSON.stringify(args)
+          }
+        }
+      )
+      expect(response.ok).toBe(true)
+      return (response.status === 204 ? undefined : await response.json()) as T
+    }
+    await callGame('configureDisconnectPolicy', [roomKey, 100])
+    await callGame('updatePresence', [playerOne.playerId, true, 900])
+    await callGame('updatePresence', [playerTwo.playerId, true, 900])
+
+    return { callGame, playerOne, playerTwo }
+  }
+
+  it('cancels a deadline on reconnect and forfeits only after a later expiry', async () => {
+    const { callGame, playerOne, playerTwo } = await createActiveRoom()
+    const now = Date.now() + 60_000
+
+    const disconnected = await callGame<PresenceUpdateResult>(
+      'updatePresence',
+      [playerOne.playerId, false, now]
+    )
+    expect(disconnected).toMatchObject({
+      status: 'updated',
+      reconnectDeadline: now + 100
+    })
+
+    const reconnected = await callGame<PresenceUpdateResult>('updatePresence', [
+      playerOne.playerId,
+      true,
+      now + 50
+    ])
+    expect(reconnected).toMatchObject({
+      status: 'updated',
+      reconnectDeadline: 0
+    })
+    expect(
+      await callGame<PresenceUpdateResult>('adjudicateDisconnects', [now + 200])
+    ).toEqual({
+      status: 'unchanged'
+    })
+
+    await callGame('updatePresence', [playerOne.playerId, false, now + 1_000])
+    const adjudicated = await callGame<PresenceUpdateResult>(
+      'adjudicateDisconnects',
+      [now + 1_100]
+    )
+    expect(adjudicated).toMatchObject({
+      status: 'adjudicated',
+      gameState: {
+        outcome: 'game-ended',
+        finishReason: 'forfeit',
+        winnerId: playerTwo.playerId
+      }
+    })
+    expect(
+      await callGame<PresenceUpdateResult>('adjudicateDisconnects', [
+        now + 1_100
+      ])
+    ).toEqual({
+      status: 'unchanged'
+    })
+  })
+
+  it('marks the game no-contest when both deadlines expire', async () => {
+    const { callGame, playerOne, playerTwo } = await createActiveRoom()
+    const now = Date.now() + 60_000
+
+    await callGame('updatePresence', [playerOne.playerId, false, now])
+    await callGame('updatePresence', [playerTwo.playerId, false, now + 10])
+    const adjudicated = await callGame<PresenceUpdateResult>(
+      'adjudicateDisconnects',
+      [now + 110]
+    )
+
+    expect(adjudicated).toMatchObject({
+      status: 'adjudicated',
+      gameState: {
+        outcome: 'game-ended',
+        finishReason: 'no-contest'
+      }
+    })
+    if (adjudicated.status === 'adjudicated') {
+      expect(adjudicated.gameState.winnerId).toBeUndefined()
+      expect(adjudicated.gameState.outcomeHistory).toEqual([])
+    }
   })
 })
 

--- a/packages/common/src/classes/GameState.test.ts
+++ b/packages/common/src/classes/GameState.test.ts
@@ -126,6 +126,7 @@ describe('GameState play validation', () => {
     gameState.applyPlay({ author: 'player-one', column: 2, dice: 6 })
 
     expect(gameState.outcome).toBe('game-ended')
+    expect(gameState.finishReason).toBe('completed')
     expect(gameState.winnerId).toBe('player-one')
     expect(gameState.outcomeHistory).toEqual([
       {
@@ -140,5 +141,31 @@ describe('GameState play validation', () => {
         dice: 1
       })
     ).toBe('game-ended')
+  })
+
+  it('records an authoritative forfeit outcome', () => {
+    const gameState = createGameState()
+
+    expect(gameState.finishByForfeit('player-one')).toBe(true)
+    expect(gameState.outcome).toBe('game-ended')
+    expect(gameState.finishReason).toBe('forfeit')
+    expect(gameState.winnerId).toBe('player-two')
+    expect(gameState.outcomeHistory).toEqual([
+      {
+        playerOne: { id: 'player-one', score: 0 },
+        playerTwo: { id: 'player-two', score: 1 }
+      }
+    ])
+    expect(gameState.finishByForfeit('player-one')).toBe(false)
+  })
+
+  it('records a no-contest without a winner or rated history', () => {
+    const gameState = createGameState()
+
+    expect(gameState.finishAsNoContest()).toBe(true)
+    expect(gameState.outcome).toBe('game-ended')
+    expect(gameState.finishReason).toBe('no-contest')
+    expect(gameState.winnerId).toBeUndefined()
+    expect(gameState.outcomeHistory).toEqual([])
   })
 })

--- a/packages/common/src/classes/GameState.ts
+++ b/packages/common/src/classes/GameState.ts
@@ -1,6 +1,7 @@
 import { type IGameState, type IPlayer } from '../interfaces'
 import {
   type Outcome,
+  type GameFinishReason,
   type Play,
   type PlayIntentRejectionReason,
   type OutcomeHistory,
@@ -31,6 +32,7 @@ export class GameState implements IGameState {
   boType: BoType
   winnerId?: string
   outcome!: Outcome
+  finishReason?: GameFinishReason
   outcomeHistory: OutcomeHistory
   rematchVote?: string
 
@@ -39,6 +41,7 @@ export class GameState implements IGameState {
     playerTwo,
     nextPlayer,
     outcome,
+    finishReason,
     rematchVote,
     winnerId,
     boType = 'indefinite',
@@ -56,6 +59,7 @@ export class GameState implements IGameState {
     this.outcomeHistory = outcomeHistory
     this.boType = boType
     this.winnerId = winnerId
+    this.finishReason = finishReason
 
     // Only assign these if we have one
     // otherwise they will be assigned in the initialize() method
@@ -86,7 +90,11 @@ export class GameState implements IGameState {
       this.spectators = previousGameState.spectators
       this.boType = previousGameState?.boType
 
-      if (this.hasBoEnded() && this.boType !== 'indefinite') {
+      if (
+        this.outcomeHistory.length > 0 &&
+        this.hasBoEnded() &&
+        this.boType !== 'indefinite'
+      ) {
         this.outcomeHistory = []
       }
     }
@@ -237,6 +245,56 @@ export class GameState implements IGameState {
     return false
   }
 
+  finishByForfeit(disconnectedPlayerId: string): boolean {
+    if (this.outcome !== 'ongoing') {
+      return false
+    }
+
+    const disconnectedPlayer =
+      disconnectedPlayerId === this.playerOne.id
+        ? this.playerOne
+        : disconnectedPlayerId === this.playerTwo.id
+          ? this.playerTwo
+          : undefined
+    if (disconnectedPlayer === undefined || disconnectedPlayer.isAi()) {
+      return false
+    }
+
+    const winner =
+      disconnectedPlayer === this.playerOne ? this.playerTwo : this.playerOne
+    this.winnerId = winner.id
+    this.outcome = 'game-ended'
+    this.finishReason = 'forfeit'
+    this.outcomeHistory.push({
+      playerOne: {
+        id: this.playerOne.id,
+        score: winner === this.playerOne ? 1 : 0
+      },
+      playerTwo: {
+        id: this.playerTwo.id,
+        score: winner === this.playerTwo ? 1 : 0
+      }
+    })
+    this.addToLogs(
+      `${winner.getName()} wins because ${disconnectedPlayer.getName()} disconnected.`
+    )
+    return true
+  }
+
+  finishAsNoContest(): boolean {
+    if (this.outcome !== 'ongoing') {
+      return false
+    }
+
+    this.winnerId = undefined
+    this.outcome = 'game-ended'
+    this.finishReason = 'no-contest'
+    this.addToLogs(
+      'The game ended with no contest because both players disconnected.'
+    )
+    return true
+  }
+
   private getColumnName(column: number) {
     if (column === 0) {
       return 'left'
@@ -283,6 +341,7 @@ export class GameState implements IGameState {
       playerTwo: this.toPlayerOutcome(this.playerTwo)
     })
     this.outcome = this.hasBoEnded() ? 'game-ended' : 'round-ended'
+    this.finishReason = 'completed'
 
     if (winner !== undefined) {
       this.addToLogs(`${winner.getName()} wins with ${winner.score} points!`)
@@ -353,6 +412,7 @@ export class GameState implements IGameState {
       playerTwo: this.playerTwo.toJson(),
       logs: this.logs.map((log) => log.toJson()),
       outcome: this.outcome,
+      finishReason: this.finishReason,
       nextPlayer: this.nextPlayer.toJson(),
       rematchVote: this.rematchVote,
       spectators: this.spectators,

--- a/packages/common/src/interfaces/IGameState.ts
+++ b/packages/common/src/interfaces/IGameState.ts
@@ -1,4 +1,9 @@
-import { type BoType, type Outcome, type OutcomeHistory } from '../types'
+import {
+  type BoType,
+  type GameFinishReason,
+  type Outcome,
+  type OutcomeHistory
+} from '../types'
 import { type ILog } from './ILog'
 import { type IPlayer } from './IPlayer'
 
@@ -12,6 +17,7 @@ export interface IGameState {
   boType: BoType
   winnerId?: string
   outcome: Outcome
+  finishReason?: GameFinishReason
   outcomeHistory: OutcomeHistory
   rematchVote?: string
 }

--- a/packages/common/src/schemas/durableObject.ts
+++ b/packages/common/src/schemas/durableObject.ts
@@ -4,6 +4,7 @@ import {
   type IdempotentMutationResult,
   type InitializeGameResult,
   type PlayGameResult,
+  type PresenceUpdateResult,
   type RematchGameResult,
   type UpdateDisplayNameResult
 } from '../types'
@@ -87,6 +88,20 @@ export const playGameResultSchema = z.union([
   }),
   updatedGameStateResultSchema
 ]) satisfies z.ZodMiniType<PlayGameResult>
+
+export const presenceUpdateResultSchema = z.union([
+  z.object({ status: z.enum(['disabled', 'ignored', 'unchanged']) }),
+  z.object({
+    status: z.literal('updated'),
+    playerId: playerIdSchema,
+    connected: z.boolean(),
+    reconnectDeadline: z.optional(z.int().check(z.minimum(0)))
+  }),
+  z.object({
+    status: z.literal('adjudicated'),
+    gameState: gameStateSchema
+  })
+]) satisfies z.ZodMiniType<PresenceUpdateResult>
 
 export const gameStateMutationResultSchema = z.union([
   initializeGameResultSchema,

--- a/packages/common/src/schemas/gameState.ts
+++ b/packages/common/src/schemas/gameState.ts
@@ -3,6 +3,7 @@ import { type IGameState, type ILog, type IPlayer } from '../interfaces'
 import {
   type BoType,
   type Difficulty,
+  type GameFinishReason,
   type Outcome,
   type OutcomeHistoryEntry,
   type PlayerOutcome
@@ -30,6 +31,12 @@ export const outcomeSchema = z.enum([
   'round-ended',
   'game-ended'
 ]) satisfies z.ZodMiniType<Outcome>
+
+export const gameFinishReasonSchema = z.enum([
+  'completed',
+  'forfeit',
+  'no-contest'
+]) satisfies z.ZodMiniType<GameFinishReason>
 
 export const logSchema = z.object({
   content: z.string(),
@@ -77,6 +84,7 @@ export const gameStateSchema = z.object({
   boType: boTypeSchema,
   winnerId: z.optional(playerIdSchema),
   outcome: outcomeSchema,
+  finishReason: z.optional(gameFinishReasonSchema),
   outcomeHistory: z.array(outcomeHistoryEntrySchema),
   rematchVote: z.optional(playerIdSchema)
 }) satisfies z.ZodMiniType<IGameState>

--- a/packages/common/src/schemas/gameStateMessage.ts
+++ b/packages/common/src/schemas/gameStateMessage.ts
@@ -122,3 +122,17 @@ export function toGamePresenceMessage(
     payload: { roomKey, playerId, connected }
   }
 }
+
+export function toGameReconnectDeadlineMessage(
+  roomKey: string,
+  playerId: string,
+  expiresAt: number,
+  requestId?: string
+): GameReconnectDeadlineEvent {
+  return {
+    version: PROTOCOL_VERSION,
+    type: 'game.reconnect-deadline',
+    ...(requestId !== undefined && { requestId }),
+    payload: { roomKey, playerId, expiresAt }
+  }
+}

--- a/packages/common/src/types/durableObject.ts
+++ b/packages/common/src/types/durableObject.ts
@@ -29,6 +29,16 @@ export interface UpdateDisplayNameCommand {
   displayName?: string
 }
 
+export type PresenceUpdateResult =
+  | { status: 'disabled' | 'ignored' | 'unchanged' }
+  | {
+      status: 'updated'
+      playerId: string
+      connected: boolean
+      reconnectDeadline?: number
+    }
+  | { status: 'adjudicated'; gameState: IGameState }
+
 export type InitializeGameResult =
   | { status: 'waiting' }
   | { status: 'created' | 'existing'; gameState: IGameState }

--- a/packages/common/src/types/outcome.ts
+++ b/packages/common/src/types/outcome.ts
@@ -1,4 +1,5 @@
 export type Outcome = 'ongoing' | 'round-ended' | 'game-ended'
+export type GameFinishReason = 'completed' | 'forfeit' | 'no-contest'
 
 export interface PlayerOutcome {
   id: string


### PR DESCRIPTION
## Summary

- add explicit completed, forfeit, and no-contest game outcomes
- persist ranked reconnect deadlines and adjudicate them idempotently with Durable Object alarms
- broadcast presence-driven deadlines and authoritative disconnect outcomes
- show localized reconnect countdowns while leaving friend and AI games unchanged