### PR TITLE
feat(api): version authenticated room mutations

### DIFF
--- a/apps/front/src/utils/api.test.ts
+++ b/apps/front/src/utils/api.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { play } from './api'
+import {
+  createWebSocketTicket,
+  initGame,
+  play,
+  updateDisplayName,
+  voteRematch
+} from './api'
 
 const room = {
   roomKey: 'room-one',
@@ -50,6 +56,44 @@ describe('mutation requests', () => {
 
     await expect(play(room, { column: 1 })).rejects.toThrow('[409:Conflict]')
     expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('uses authenticated versioned room endpoints without player IDs', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          ticket: 'a'.repeat(64),
+          expiresAt: Date.now() + 30_000
+        })
+      )
+    localStorage.setItem('displayName', 'Dice Friend')
+
+    await initGame(room, { playerType: 'human', boType: 1 })
+    await voteRematch(room, { boType: 3 })
+    await updateDisplayName(room, { displayName: 'A/B ? Player' })
+    await createWebSocketTicket(room)
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      expect.stringContaining(`/v1/rooms/${room.roomKey}/init`),
+      expect.stringContaining(`/v1/rooms/${room.roomKey}/rematch`),
+      expect.stringContaining(`/v1/rooms/${room.roomKey}/display-name`),
+      expect.stringContaining(`/v1/rooms/${room.roomKey}/websocket-ticket`)
+    ])
+    expect(
+      fetchMock.mock.calls.every(
+        ([url]) => !url.toString().includes(room.playerId)
+      )
+    ).toBe(true)
+    expect(fetchMock.mock.calls[0][1]?.body).toBe(
+      '{"playerType":"human","boType":1,"displayName":"Dice Friend"}'
+    )
+    expect(fetchMock.mock.calls[1][1]?.body).toBe('{"boType":3}')
+    expect(fetchMock.mock.calls[2][1]?.body).toBe(
+      '{"displayName":"A/B ? Player"}'
+    )
   })
 
   it('reports a validated API error code and message', async () => {

--- a/apps/front/src/utils/api.ts
+++ b/apps/front/src/utils/api.ts
@@ -110,11 +110,10 @@ export async function redeemIdentityTransfer(
 }
 
 export async function createWebSocketTicket({
-  playerId,
   roomKey
 }: IdentificationParams): Promise<WebSocketTicket> {
   const response = await sendApiRequest(
-    `/${roomKey}/${playerId}/websocket-ticket`,
+    `/v1/rooms/${roomKey}/websocket-ticket`,
     'POST'
   )
   const result = webSocketTicketSchema.safeParse(await response.json())
@@ -131,50 +130,32 @@ interface InitGameRequestParams extends Omit<GameSettings, 'boType'> {
   boType?: GameSettings['boType']
 }
 export async function initGame(
-  { playerId, roomKey }: IdentificationParams,
+  { roomKey }: IdentificationParams,
   { boType, difficulty, playerType }: InitGameRequestParams
 ) {
-  const urlSearchParams = new URLSearchParams()
+  const displayName = getStoredDisplayName()
+  const body =
+    playerType === 'ai'
+      ? { playerType, difficulty, boType }
+      : {
+          playerType,
+          boType,
+          ...(displayName !== null && { displayName })
+        }
 
-  if (playerType === 'ai' && difficulty !== undefined) {
-    urlSearchParams.append('difficulty', difficulty)
-  } else {
-    const displayName = getStoredDisplayName()
-    if (displayName !== null) {
-      urlSearchParams.append('displayName', displayName)
-    }
-  }
-
-  if (boType !== undefined) {
-    urlSearchParams.append('boType', String(boType))
-  }
-
-  const urlSearchParamsString = urlSearchParams.toString()
-
-  const queryParamsString =
-    urlSearchParamsString.length > 0 ? '?' + urlSearchParamsString : ''
-
-  const path = `/${roomKey}/${playerId}/init${queryParamsString}`
-
-  await sendMutationRequest(path, 'POST')
+  await sendMutationRequest(`/v1/rooms/${roomKey}/init`, 'POST', body)
 }
 
 // Pas besoin de repréciser `boType` si il change pas de la partie en cours
 type VoteRematchRequestParams = Partial<Omit<GameSettings, 'playerType'>>
 export async function voteRematch(
-  { playerId, roomKey }: IdentificationParams,
+  { roomKey }: IdentificationParams,
   { boType, difficulty }: VoteRematchRequestParams = {}
 ) {
-  const urlSearchParams = new URLSearchParams()
-  if (boType !== undefined) {
-    urlSearchParams.append('boType', String(boType))
-  }
-  if (difficulty !== undefined) {
-    urlSearchParams.append('difficulty', difficulty)
-  }
-
-  const path = `/${roomKey}/${playerId}/rematch?${urlSearchParams.toString()}`
-  await sendMutationRequest(path, 'POST')
+  await sendMutationRequest(`/v1/rooms/${roomKey}/rematch`, 'POST', {
+    boType,
+    difficulty
+  })
 }
 
 interface PlayRequestParams {
@@ -191,19 +172,16 @@ interface UpdateDisplayNameRequestParams {
   displayName: string
 }
 export async function updateDisplayName(
-  { playerId, roomKey }: IdentificationParams,
+  { roomKey }: IdentificationParams,
   { displayName }: UpdateDisplayNameRequestParams
 ) {
-  const path = `/${roomKey}/${playerId}/displayName/${displayName}`
-  await sendMutationRequest(path, 'POST')
+  await sendMutationRequest(`/v1/rooms/${roomKey}/display-name`, 'POST', {
+    displayName
+  })
 }
 
-export async function deleteDisplayName({
-  playerId,
-  roomKey
-}: IdentificationParams) {
-  const path = `/${roomKey}/${playerId}/displayName`
-  await sendMutationRequest(path, 'DELETE')
+export async function deleteDisplayName({ roomKey }: IdentificationParams) {
+  await sendMutationRequest(`/v1/rooms/${roomKey}/display-name`, 'DELETE')
 }
 
 async function sendMutationRequest(

--- a/apps/worker/src/durable-objects/GameStateDurableObject.ts
+++ b/apps/worker/src/durable-objects/GameStateDurableObject.ts
@@ -328,6 +328,13 @@ export class GameStateDurableObject extends createDurable({
   ): RematchGameResult {
     const gameState = this.getInitializedGameState()
 
+    if (
+      playerId !== gameState.playerOne.id &&
+      playerId !== gameState.playerTwo.id
+    ) {
+      return { status: 'unknown-player' }
+    }
+
     if (gameState.outcome === 'ongoing') {
       return { status: 'game-ongoing' }
     }

--- a/apps/worker/src/endpoints/deleteDisplayName.ts
+++ b/apps/worker/src/endpoints/deleteDisplayName.ts
@@ -1,56 +1,32 @@
-import { status } from 'itty-router'
-import {
-  GameState,
-  idempotentUpdateDisplayNameResultSchema
-} from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type MutationRequestWithProps } from '../types/itty'
-import { makeAiPlay } from '../utils/ai'
 import {
-  broadcastGameState,
-  getGameStateDurableObject
-} from '../utils/endpoints'
-import { apiError } from '../utils/http'
-import { idempotencyConflict } from '../utils/idempotency'
+  type AuthenticatedMutationRoomRequestWithProps,
+  type MutationRequestWithProps
+} from '../types/itty'
+import { executeDisplayNameUpdate } from './displayName'
 
 export async function deleteDisplayName(
   request: MutationRequestWithProps,
   cloudflareEnvironment: CloudflareEnvironment,
   context: ExecutionContext
 ) {
-  const result = idempotentUpdateDisplayNameResultSchema.parse(
-    await getGameStateDurableObject(request).updateDisplayName(
-      request.mutationId,
-      request.playerId,
-      undefined
-    )
+  return await executeDisplayNameUpdate(
+    request,
+    undefined,
+    cloudflareEnvironment,
+    context
   )
+}
 
-  if (result.idempotencyStatus === 'conflict') {
-    return idempotencyConflict(request.requestId)
-  }
-
-  const mutation = result.value
-
-  if (mutation.status === 'unknown-player') {
-    return apiError({
-      status: 400,
-      code: 'UNEXPECTED_PLAYER_ID',
-      message: 'Unexpected playerId received.',
-      requestId: request.requestId
-    })
-  }
-
-  await broadcastGameState(mutation.gameState, request, cloudflareEnvironment)
-
-  const gameState = GameState.fromJson(mutation.gameState)
-  if (
-    gameState.outcome === 'ongoing' &&
-    gameState.playerTwo.isAi() &&
-    gameState.nextPlayer.equals(gameState.playerTwo)
-  ) {
-    makeAiPlay(gameState, request, cloudflareEnvironment, context)
-  }
-
-  return status(200)
+export async function deleteRoomDisplayName(
+  request: Request & AuthenticatedMutationRoomRequestWithProps,
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+) {
+  return await executeDisplayNameUpdate(
+    request,
+    undefined,
+    cloudflareEnvironment,
+    context
+  )
 }

--- a/apps/worker/src/endpoints/displayName.ts
+++ b/apps/worker/src/endpoints/displayName.ts
@@ -2,10 +2,14 @@ import { status } from 'itty-router'
 import {
   displayNameRouteParamsSchema,
   GameState,
-  idempotentUpdateDisplayNameResultSchema
+  idempotentUpdateDisplayNameResultSchema,
+  updateDisplayNameSchema
 } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type MutationRequestWithProps } from '../types/itty'
+import {
+  type AuthenticatedMutationRoomRequestWithProps,
+  type MutationRequestWithProps
+} from '../types/itty'
 import { makeAiPlay } from '../utils/ai'
 import {
   broadcastGameState,
@@ -33,11 +37,50 @@ export async function displayName(
     return invalidRouteParameters(request.requestId)
   }
 
+  return await executeDisplayNameUpdate(
+    request,
+    params.data.displayName,
+    cloudflareEnvironment,
+    context
+  )
+}
+
+export async function updateRoomDisplayName(
+  request: Request & AuthenticatedMutationRoomRequestWithProps,
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+) {
+  const body = updateDisplayNameSchema.safeParse(
+    await request.json().catch(() => undefined)
+  )
+  if (!body.success) {
+    return apiError({
+      status: 400,
+      code: 'INVALID_DISPLAY_NAME_REQUEST',
+      message: 'The display-name request is invalid.',
+      requestId: request.requestId
+    })
+  }
+
+  return await executeDisplayNameUpdate(
+    request,
+    body.data.displayName,
+    cloudflareEnvironment,
+    context
+  )
+}
+
+export async function executeDisplayNameUpdate(
+  request: AuthenticatedMutationRoomRequestWithProps,
+  displayName: string | undefined,
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+) {
   const result = idempotentUpdateDisplayNameResultSchema.parse(
     await getGameStateDurableObject(request).updateDisplayName(
       request.mutationId,
-      request.playerId,
-      params.data.displayName
+      request.principal.playerId,
+      displayName
     )
   )
 
@@ -49,9 +92,9 @@ export async function displayName(
 
   if (mutation.status === 'unknown-player') {
     return apiError({
-      status: 400,
-      code: 'UNEXPECTED_PLAYER_ID',
-      message: 'Unexpected playerId received.',
+      status: 403,
+      code: 'NOT_A_PLAYER',
+      message: 'Only a player in this game can change their display name.',
       requestId: request.requestId
     })
   }

--- a/apps/worker/src/endpoints/init.ts
+++ b/apps/worker/src/endpoints/init.ts
@@ -1,11 +1,18 @@
 import { status } from 'itty-router'
 import {
+  AI_PLAYER_ID,
   GameState,
   idempotentInitializeGameResultSchema,
-  initGameQuerySchema
+  initGameQuerySchema,
+  initializeRoomSchema,
+  type BoType,
+  type Difficulty
 } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type MutationRequestWithProps } from '../types/itty'
+import {
+  type AuthenticatedMutationRoomRequestWithProps,
+  type MutationRequestWithProps
+} from '../types/itty'
 import { makeAiPlay } from '../utils/ai'
 import {
   broadcastGameState,
@@ -48,13 +55,69 @@ export async function init(
     })
   }
 
-  const result = idempotentInitializeGameResultSchema.parse(
-    await getGameStateDurableObject(request).initializeGame({
-      mutationId: request.mutationId,
+  return await executeInitializeGame(
+    request,
+    {
       playerId: request.playerId,
       displayName: query.data.displayName,
       difficulty: gameSettings.value.difficulty,
       boType: gameSettings.value.boType
+    },
+    cloudflareEnvironment,
+    context
+  )
+}
+
+export async function initializeRoom(
+  request: Request & AuthenticatedMutationRoomRequestWithProps,
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+) {
+  const body = initializeRoomSchema.safeParse(
+    await request.json().catch(() => undefined)
+  )
+  if (!body.success) {
+    return apiError({
+      status: 400,
+      code: 'INVALID_INITIALIZE_GAME_REQUEST',
+      message: 'The game initialization request is invalid.',
+      requestId: request.requestId
+    })
+  }
+
+  return await executeInitializeGame(
+    request,
+    {
+      playerId:
+        body.data.playerType === 'ai'
+          ? AI_PLAYER_ID
+          : request.principal.playerId,
+      displayName:
+        body.data.playerType === 'human' ? body.data.displayName : undefined,
+      difficulty:
+        body.data.playerType === 'ai' ? body.data.difficulty : undefined,
+      boType: body.data.boType
+    },
+    cloudflareEnvironment,
+    context
+  )
+}
+
+async function executeInitializeGame(
+  request: AuthenticatedMutationRoomRequestWithProps,
+  player: {
+    playerId: string
+    displayName?: string
+    difficulty?: Difficulty
+    boType?: BoType
+  },
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+) {
+  const result = idempotentInitializeGameResultSchema.parse(
+    await getGameStateDurableObject(request).initializeGame({
+      mutationId: request.mutationId,
+      ...player
     })
   )
 

--- a/apps/worker/src/endpoints/rematch.ts
+++ b/apps/worker/src/endpoints/rematch.ts
@@ -2,10 +2,15 @@ import { status } from 'itty-router'
 import {
   GameState,
   gameSettingsQuerySchema,
-  idempotentRematchGameResultSchema
+  idempotentRematchGameResultSchema,
+  rematchRoomSchema,
+  type GameSettings
 } from '@knucklebones/common'
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type MutationRequestWithProps } from '../types/itty'
+import {
+  type AuthenticatedMutationRoomRequestWithProps,
+  type MutationRequestWithProps
+} from '../types/itty'
 import { makeAiPlay } from '../utils/ai'
 import {
   broadcastGameState,
@@ -47,11 +52,53 @@ export async function rematch(
     })
   }
 
+  return await executeRematch(
+    request,
+    request.playerId,
+    gameSettings.value,
+    cloudflareEnvironment,
+    context
+  )
+}
+
+export async function rematchRoom(
+  request: Request & AuthenticatedMutationRoomRequestWithProps,
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+) {
+  const body = rematchRoomSchema.safeParse(
+    await request.json().catch(() => undefined)
+  )
+  if (!body.success) {
+    return apiError({
+      status: 400,
+      code: 'INVALID_REMATCH_REQUEST',
+      message: 'The rematch request is invalid.',
+      requestId: request.requestId
+    })
+  }
+
+  return await executeRematch(
+    request,
+    request.principal.playerId,
+    body.data,
+    cloudflareEnvironment,
+    context
+  )
+}
+
+async function executeRematch(
+  request: AuthenticatedMutationRoomRequestWithProps,
+  playerId: string,
+  gameSettings: Partial<Omit<GameSettings, 'playerType'>>,
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+) {
   const result = idempotentRematchGameResultSchema.parse(
     await getGameStateDurableObject(request).rematch(
       request.mutationId,
-      request.playerId,
-      gameSettings.value
+      playerId,
+      gameSettings
     )
   )
 
@@ -66,6 +113,15 @@ export async function rematch(
       status: 409,
       code: 'GAME_STILL_ONGOING',
       message: "The game is still ongoing. Can't rematch.",
+      requestId: request.requestId
+    })
+  }
+
+  if (mutation.status === 'unknown-player') {
+    return apiError({
+      status: 403,
+      code: 'NOT_A_PLAYER',
+      message: 'Only a player in this game can request a rematch.',
       requestId: request.requestId
     })
   }

--- a/apps/worker/src/endpoints/webSocketTicket.ts
+++ b/apps/worker/src/endpoints/webSocketTicket.ts
@@ -1,9 +1,9 @@
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
-import { type BaseRequestWithProps } from '../types/itty'
+import { type AuthenticatedRoomRequestWithProps } from '../types/itty'
 import { enforceRateLimit } from '../utils/rateLimit'
 
 export async function createWebSocketTicket(
-  request: Request & BaseRequestWithProps,
+  request: Request & AuthenticatedRoomRequestWithProps,
   cloudflareEnvironment: CloudflareEnvironment
 ): Promise<Response> {
   const rateLimit = await enforceRateLimit(

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -4,11 +4,13 @@ import { Toucan } from 'toucan-js'
 import {
   createPlayer,
   createWebSocketTicket,
+  deleteRoomDisplayName,
   deleteDisplayName,
   displayName,
   getRankedProfile,
   getMatchmakingStatus,
   init,
+  initializeRoom,
   createIdentityTransfer,
   joinMatchmaking,
   leaveMatchmaking,
@@ -16,12 +18,14 @@ import {
   play,
   playIntent,
   rematch,
+  rematchRoom,
   redeemIdentityTransfer,
   redeemIdentityRecovery,
   revokeDeviceCredential,
   revokeOtherDeviceCredentials,
   rotateDeviceCredential,
   rotateIdentityRecovery,
+  updateRoomDisplayName,
   verifyPlayer,
   webSocket
 } from '../endpoints'
@@ -75,7 +79,20 @@ router
     withDurables({ parse: true }),
     authenticatePlayerRequest
   )
+  .post('/v1/rooms/:roomKey/websocket-ticket', createWebSocketTicket)
+  .post('/v1/rooms/:roomKey/init', withAuthenticatedMutationId, initializeRoom)
   .post('/v1/rooms/:roomKey/play', withAuthenticatedMutationId, playIntent)
+  .post('/v1/rooms/:roomKey/rematch', withAuthenticatedMutationId, rematchRoom)
+  .post(
+    '/v1/rooms/:roomKey/display-name',
+    withAuthenticatedMutationId,
+    updateRoomDisplayName
+  )
+  .delete(
+    '/v1/rooms/:roomKey/display-name',
+    withAuthenticatedMutationId,
+    deleteRoomDisplayName
+  )
   .all(
     '/:roomKey/:playerId/*',
     withDurables({ parse: true }),

--- a/apps/worker/test/worker.integration.test.ts
+++ b/apps/worker/test/worker.integration.test.ts
@@ -538,6 +538,138 @@ describe('atomic idempotent room mutations', () => {
   })
 })
 
+describe('versioned authenticated room API', () => {
+  function mutationRequest(
+    player: PlayerCredentials,
+    body?: unknown
+  ): RequestInit {
+    return {
+      method: 'POST',
+      headers: {
+        ...authorization(player),
+        'Idempotency-Key': crypto.randomUUID(),
+        ...(body !== undefined && { 'Content-Type': 'application/json' })
+      },
+      ...(body !== undefined && { body: JSON.stringify(body) })
+    }
+  }
+
+  it('derives room actors from credentials and accepts settings in JSON', async () => {
+    const playerOne = await createPlayer()
+    const playerTwo = await createPlayer()
+    const roomKey = crypto.randomUUID()
+
+    const first = await request(
+      `/v1/rooms/${roomKey}/init`,
+      mutationRequest(playerOne, {
+        playerType: 'human',
+        displayName: 'Player / One?',
+        boType: 1
+      })
+    )
+    const second = await request(
+      `/v1/rooms/${roomKey}/init`,
+      mutationRequest(playerTwo, { playerType: 'human', boType: 1 })
+    )
+    const renamed = await request(
+      `/v1/rooms/${roomKey}/display-name`,
+      mutationRequest(playerOne, { displayName: 'Updated / Name?' })
+    )
+    const ticket = await request(
+      `/v1/rooms/${roomKey}/websocket-ticket`,
+      mutationRequest(playerOne)
+    )
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    expect(renamed.status).toBe(200)
+    expect(ticket.status).toBe(201)
+    expect(webSocketTicketSchema.safeParse(await ticket.json()).success).toBe(
+      true
+    )
+  })
+
+  it('rejects malformed or identity-bearing room bodies', async () => {
+    const player = await createPlayer()
+    const roomKey = crypto.randomUUID()
+
+    for (const body of [
+      { playerType: 'human', playerId: player.playerId },
+      { playerType: 'ai' },
+      { playerType: 'human', boType: 2 }
+    ]) {
+      const response = await request(
+        `/v1/rooms/${roomKey}/init`,
+        mutationRequest(player, body)
+      )
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: 'INVALID_INITIALIZE_GAME_REQUEST' }
+      })
+    }
+  })
+
+  it('rejects rematch votes from authenticated spectators', async () => {
+    const playerOne = await createPlayer()
+    const playerTwo = await createPlayer()
+    const spectator = await createPlayer()
+    const roomKey = crypto.randomUUID()
+
+    for (const player of [playerOne, playerTwo]) {
+      expect(
+        (
+          await request(
+            `/v1/rooms/${roomKey}/init`,
+            mutationRequest(player, { playerType: 'human', boType: 1 })
+          )
+        ).status
+      ).toBe(200)
+    }
+
+    const environment = await server.getWorker().getEnv()
+    const durableObjectId =
+      environment.GAME_STATE_DURABLE_OBJECT.idFromName(roomKey)
+    const game = environment.GAME_STATE_DURABLE_OBJECT.get(durableObjectId)
+    const callGame = async (method: string, args: unknown[]) => {
+      const response = await game.fetch(
+        `https://itty-durable/do/call/${method}`,
+        {
+          headers: {
+            'do-name': roomKey,
+            'do-content': JSON.stringify(args)
+          }
+        }
+      )
+      expect(response.ok).toBe(true)
+      return response
+    }
+    const now = Date.now() + 60_000
+    await callGame('configureDisconnectPolicy', [roomKey, 100])
+    await callGame('updatePresence', [playerOne.playerId, true, now])
+    await callGame('updatePresence', [playerTwo.playerId, true, now])
+    await callGame('updatePresence', [playerOne.playerId, false, now])
+    await callGame('adjudicateDisconnects', [now + 100])
+
+    const rematch = await request(
+      `/v1/rooms/${roomKey}/rematch`,
+      mutationRequest(spectator, {})
+    )
+    const displayName = await request(
+      `/v1/rooms/${roomKey}/display-name`,
+      mutationRequest(spectator, { displayName: 'Intruder' })
+    )
+
+    expect(rematch.status).toBe(403)
+    await expect(rematch.json()).resolves.toMatchObject({
+      error: { code: 'NOT_A_PLAYER' }
+    })
+    expect(displayName.status).toBe(403)
+    await expect(displayName.json()).resolves.toMatchObject({
+      error: { code: 'NOT_A_PLAYER' }
+    })
+  })
+})
+
 describe('ranked disconnect adjudication', () => {
   async function createActiveRoom() {
     const playerOne = await createPlayer()

--- a/packages/common/src/schemas/api.ts
+++ b/packages/common/src/schemas/api.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod/mini'
 import { type ApiErrorBody } from '../types'
+import { boTypeSchema, difficultySchema } from './gameState'
 import {
   displayNameSchema,
   playerIdSchema,
@@ -42,6 +43,28 @@ export const playRouteParamsSchema = z.object({
 
 export const playIntentSchema = z.strictObject({
   column: z.union([z.literal(0), z.literal(1), z.literal(2)])
+})
+
+export const initializeRoomSchema = z.union([
+  z.strictObject({
+    playerType: z.literal('human'),
+    displayName: z.optional(displayNameSchema),
+    boType: z.optional(boTypeSchema)
+  }),
+  z.strictObject({
+    playerType: z.literal('ai'),
+    difficulty: difficultySchema,
+    boType: z.optional(boTypeSchema)
+  })
+])
+
+export const rematchRoomSchema = z.strictObject({
+  boType: z.optional(boTypeSchema),
+  difficulty: z.optional(difficultySchema)
+})
+
+export const updateDisplayNameSchema = z.strictObject({
+  displayName: displayNameSchema
 })
 
 export const gameSettingsQuerySchema = z.object({

--- a/packages/common/src/schemas/durableObject.ts
+++ b/packages/common/src/schemas/durableObject.ts
@@ -63,7 +63,7 @@ export const initializeGameResultSchema = z.union([
 ]) satisfies z.ZodMiniType<InitializeGameResult>
 
 export const rematchGameResultSchema = z.union([
-  z.object({ status: z.enum(['game-ongoing', 'unchanged']) }),
+  z.object({ status: z.enum(['game-ongoing', 'unchanged', 'unknown-player']) }),
   updatedGameStateResultSchema
 ]) satisfies z.ZodMiniType<RematchGameResult>
 

--- a/packages/common/src/types/durableObject.ts
+++ b/packages/common/src/types/durableObject.ts
@@ -44,7 +44,7 @@ export type InitializeGameResult =
   | { status: 'created' | 'existing'; gameState: IGameState }
 
 export type RematchGameResult =
-  | { status: 'game-ongoing' | 'unchanged' }
+  | { status: 'game-ongoing' | 'unchanged' | 'unknown-player' }
   | { status: 'updated'; gameState: IGameState }
 
 export type UpdateDisplayNameResult =


### PR DESCRIPTION
## Summary

- move room initialization, rematches, display-name updates, and WebSocket ticket issuance to authenticated v1 endpoints
- validate settings and display names from strict JSON bodies while deriving actors from credentials
- prevent spectators from voting for rematches or changing player display names
- migrate the frontend and regression coverage away from identity-bearing room command URLs