### PR TITLE
feat(worker): add credential-safe observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ and must be applied before deploying compatible staging or production code.
 `SENTRY_DSN` is an environment-scoped Worker secret. Deployment credentials
 remain in the repository's GitHub Actions secrets and must never be committed.
 
+## Operations
+
+Staging and production emit credential-free JSON events to Worker logs.
+`http.request` records the normalized route, status, stable error code, request
+ID, and duration. WebSocket events record accepted connections, rejected client
+messages, closes, and errors without player IDs, room IDs, tickets, URLs, or
+message bodies. Sentry receives a copy of the request with its query string and
+sensitive headers removed.
+
+Configure log-based alerts for these initial thresholds:
+
+- five or more `5xx` responses, or a `5xx` rate above 1%, within five minutes;
+- more than 50 authentication failures in one minute;
+- more than 25 `STALE_REVISION` or `IDEMPOTENCY_KEY_REUSED` responses in five
+  minutes;
+- more than 10 rejected WebSocket messages or WebSocket errors in five minutes.
+
+Investigations should correlate events using `request_id`. Never add raw
+authorization headers, credentials, transfer tokens, recovery phrases, query
+strings, complete WebSocket URLs, or request/response bodies to events.
+
 ## Legal disclaimer
 
 The original Knucklebones game in Cult of the Lamb was created by Massive Monster. This is a fan-site and not an official implementation by Massive Monster. You can find the original game on the [Cult of the Lamb](https://www.cultofthelamb.com/) website.

--- a/apps/worker/src/durable-objects/WebSocketDurableObject.ts
+++ b/apps/worker/src/durable-objects/WebSocketDurableObject.ts
@@ -15,6 +15,7 @@ import {
 import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
 import { createCredential, hashCredential } from '../utils/credentials'
 import { apiError } from '../utils/http'
+import { recordOperationalEvent } from '../utils/observability'
 
 const WEB_SOCKET_TICKET_TTL_MS = 30_000
 const WEB_SOCKET_TICKETS_STORAGE_KEY = 'websocket-tickets'
@@ -186,9 +187,23 @@ export class WebSocketDurableObject {
       )
       await this.reportPresence(session, true)
     }
+
+    recordOperationalEvent(this.cloudflareEnvironment.ENVIRONMENT, {
+      event: 'websocket.connection',
+      outcome: 'accepted',
+      role: session.role,
+      player_connection_count: this.state.getWebSockets(
+        `player:${session.playerId}`
+      ).length
+    })
   }
 
   async webSocketMessage(webSocket: WebSocket) {
+    recordOperationalEvent(this.cloudflareEnvironment.ENVIRONMENT, {
+      event: 'websocket.message',
+      outcome: 'rejected',
+      reason: 'client-messages-disabled'
+    })
     webSocket.close(1008, 'Client messages are not supported.')
   }
 
@@ -212,12 +227,28 @@ export class WebSocketDurableObject {
     }
 
     if (!wasClean) {
-      this.sentry.captureMessage(`${code} - ${reason}`, 'error')
+      this.sentry.captureMessage(
+        `WebSocket closed unexpectedly with code ${code}.`,
+        'error'
+      )
     }
+
+    recordOperationalEvent(this.cloudflareEnvironment.ENVIRONMENT, {
+      event: 'websocket.connection',
+      outcome: 'closed',
+      clean: wasClean,
+      close_code: code,
+      final_player_connection:
+        session !== undefined && !this.hasOpenSession(session.playerId)
+    })
   }
 
   async webSocketError(webSocket: WebSocket, error: unknown) {
     this.sentry.captureException(error)
+    recordOperationalEvent(this.cloudflareEnvironment.ENVIRONMENT, {
+      event: 'websocket.connection',
+      outcome: 'error'
+    })
   }
 
   broadcast(message: string) {

--- a/apps/worker/src/utils/http.ts
+++ b/apps/worker/src/utils/http.ts
@@ -27,7 +27,10 @@ export function apiError({
     } satisfies ApiErrorBody,
     {
       status,
-      headers: { 'X-Request-Id': requestId }
+      headers: {
+        'X-Request-Id': requestId,
+        'X-Knucklebones-Error-Code': code
+      }
     }
   )
 }

--- a/apps/worker/src/utils/observability.ts
+++ b/apps/worker/src/utils/observability.ts
@@ -1,0 +1,83 @@
+import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
+
+type OperationalValue = string | number | boolean | undefined
+
+interface OperationalEvent {
+  event: string
+  [key: string]: OperationalValue
+}
+
+interface HttpRequestEventOptions {
+  request: Request
+  response: Response
+  requestId: string
+  environment: CloudflareEnvironment['ENVIRONMENT']
+  startedAt: number
+}
+
+export function recordHttpRequest({
+  request,
+  response,
+  requestId,
+  environment,
+  startedAt
+}: HttpRequestEventOptions): void {
+  recordOperationalEvent(environment, {
+    event: 'http.request',
+    request_id: requestId,
+    method: request.method,
+    route: classifyRoute(new URL(request.url).pathname),
+    status: response.status,
+    duration_ms: Math.max(0, Date.now() - startedAt),
+    error_code: response.headers.get('X-Knucklebones-Error-Code') ?? undefined
+  })
+}
+
+export function recordOperationalEvent(
+  environment: CloudflareEnvironment['ENVIRONMENT'],
+  event: OperationalEvent
+): void {
+  if (environment === 'development') {
+    return
+  }
+
+  console.log(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      environment,
+      ...event
+    })
+  )
+}
+
+export function classifyRoute(pathname: string): string {
+  const segments = pathname.split('/').filter(Boolean)
+
+  if (segments[0] === 'v1' && segments[1] === 'rooms') {
+    return ['/v1/rooms/:roomKey', ...segments.slice(3)].join('/')
+  }
+
+  if (segments[0] === 'v1' && segments[1] === 'identity') {
+    if (segments[2] === 'credentials' && segments.length > 3) {
+      return '/v1/identity/credentials/:credentialId'
+    }
+    return `/${segments.join('/')}`
+  }
+
+  if (segments[0] === 'players' || segments[0] === 'matchmaking') {
+    if (segments.length === 1) {
+      return `/${segments[0]}`
+    }
+    return [`/${segments[0]}/:playerId`, ...segments.slice(2)].join('/')
+  }
+
+  if (segments.length === 2 && segments[1] === 'websocket') {
+    return '/:roomKey/websocket'
+  }
+
+  if (segments.length >= 3) {
+    return ['/:roomKey/:playerId', ...segments.slice(2, 3)].join('/')
+  }
+
+  return '/unmatched'
+}

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -42,6 +42,7 @@ import {
   withAuthenticatedMutationId,
   withMutationId
 } from '../utils/idempotency'
+import { recordHttpRequest } from '../utils/observability'
 import { validateRequestPath } from '../utils/validation'
 
 export { GameStateDurableObject } from '../durable-objects/GameStateDurableObject'
@@ -121,6 +122,7 @@ export default {
     cloudflareEnvironment: CloudflareEnvironment,
     context: ExecutionContext
   ) {
+    const startedAt = Date.now()
     const requestId = crypto.randomUUID()
     const requestWithId = Object.assign(request, {
       requestId
@@ -132,19 +134,30 @@ export default {
     })
     sentry.setTag('request_id', requestId)
     const { corsify } = createCors(cloudflareEnvironment.ENVIRONMENT)
+    const finalize = (response: Response) => {
+      const finalizedResponse = withRequestId(
+        corsify(response, requestWithId),
+        requestId
+      )
+      recordHttpRequest({
+        request,
+        response: finalizedResponse,
+        requestId,
+        environment: cloudflareEnvironment.ENVIRONMENT,
+        startedAt
+      })
+      return finalizedResponse
+    }
 
     try {
       if (isWebSocketEndpointCalled(requestWithId)) {
         const response = await webSocket(requestWithId, cloudflareEnvironment)
-        return withRequestId(response, requestId)
+        return finalize(response)
       }
 
       const invalidPathResponse = validateRequestPath(requestWithId)
       if (invalidPathResponse !== undefined) {
-        return withRequestId(
-          corsify(invalidPathResponse, requestWithId),
-          requestId
-        )
+        return finalize(invalidPathResponse)
       }
 
       const response = await router.fetch(
@@ -152,7 +165,7 @@ export default {
         cloudflareEnvironment,
         context
       )
-      return withRequestId(corsify(response, requestWithId), requestId)
+      return finalize(response)
     } catch (error: unknown) {
       sentry.captureException(error)
       const response = apiError({
@@ -162,7 +175,7 @@ export default {
         requestId,
         retryable: true
       })
-      return withRequestId(corsify(response, requestWithId), requestId)
+      return finalize(response)
     }
   }
 }

--- a/apps/worker/test/http.test.ts
+++ b/apps/worker/test/http.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolveFrontendOrigin } from '../src/utils/http'
+import {
+  resolveFrontendOrigin,
+  sanitizeRequestForSentry
+} from '../src/utils/http'
 
 describe('frontend origin policy', () => {
   it('allows only the public site in production', () => {
@@ -32,5 +35,32 @@ describe('frontend origin policy', () => {
     expect(
       resolveFrontendOrigin('http://localhost.evil.test:5173', 'development')
     ).toBeUndefined()
+  })
+})
+
+describe('Sentry request sanitization', () => {
+  it('removes query strings and sensitive headers', () => {
+    const sanitized = sanitizeRequestForSentry(
+      new Request(
+        'https://api.knucklebones.io/room/websocket?ticket=secret-ticket',
+        {
+          headers: {
+            Authorization: 'Bearer secret-credential',
+            Cookie: 'identity=secret-cookie',
+            'User-Agent': 'test-browser',
+            'Idempotency-Key': '11111111-1111-4111-8111-111111111111'
+          }
+        }
+      ),
+      '22222222-2222-4222-8222-222222222222'
+    )
+
+    expect(sanitized.url).toBe('https://api.knucklebones.io/room/websocket')
+    expect(sanitized.headers.get('Authorization')).toBeNull()
+    expect(sanitized.headers.get('Cookie')).toBeNull()
+    expect(sanitized.headers.get('User-Agent')).toBe('test-browser')
+    expect(sanitized.headers.get('X-Request-Id')).toBe(
+      '22222222-2222-4222-8222-222222222222'
+    )
   })
 })

--- a/apps/worker/test/observability.test.ts
+++ b/apps/worker/test/observability.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { classifyRoute, recordHttpRequest } from '../src/utils/observability'
+
+describe('operational events', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('normalizes public identifiers out of route labels', () => {
+    expect(
+      classifyRoute(
+        '/v1/rooms/11111111-1111-4111-8111-111111111111/display-name'
+      )
+    ).toBe('/v1/rooms/:roomKey/display-name')
+    expect(
+      classifyRoute(
+        '/v1/identity/credentials/22222222-2222-4222-8222-222222222222'
+      )
+    ).toBe('/v1/identity/credentials/:credentialId')
+  })
+
+  it('logs structured outcomes without request secrets', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const request = new Request(
+      'https://api.knucklebones.io/v1/rooms/11111111-1111-4111-8111-111111111111/play?ticket=secret-ticket',
+      { headers: { Authorization: 'Bearer secret-credential' } }
+    )
+    const response = new Response(null, {
+      status: 409,
+      headers: { 'X-Knucklebones-Error-Code': 'STALE_REVISION' }
+    })
+
+    recordHttpRequest({
+      request,
+      response,
+      requestId: '33333333-3333-4333-8333-333333333333',
+      environment: 'staging',
+      startedAt: Date.now()
+    })
+
+    expect(consoleLog).toHaveBeenCalledOnce()
+    const serializedEvent = consoleLog.mock.calls[0][0] as string
+    expect(JSON.parse(serializedEvent)).toMatchObject({
+      environment: 'staging',
+      event: 'http.request',
+      route: '/v1/rooms/:roomKey/play',
+      status: 409,
+      error_code: 'STALE_REVISION'
+    })
+    expect(serializedEvent).not.toContain('secret-ticket')
+    expect(serializedEvent).not.toContain('secret-credential')
+    expect(serializedEvent).not.toContain(
+      '11111111-1111-4111-8111-111111111111'
+    )
+  })
+
+  it('keeps local test and development logs quiet', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+    recordHttpRequest({
+      request: new Request('http://localhost:8787/players'),
+      response: new Response(null, { status: 201 }),
+      requestId: '33333333-3333-4333-8333-333333333333',
+      environment: 'development',
+      startedAt: Date.now()
+    })
+    expect(consoleLog).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- emit structured HTTP outcomes with normalized routes, request IDs, stable error codes, and durations
- record WebSocket connection lifecycle and rejected client-message events without identity or payload data
- verify query strings, authorization, cookies, tickets, credentials, and public route IDs are excluded
- document initial log-based alert thresholds and request correlation guidance