### PR TITLE
ci(worker): apply D1 migrations before deploy

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -34,6 +34,12 @@ jobs:
 
       - run: pnpm test:e2e
 
+      - name: Apply production database migrations
+        run: pnpm --filter @knucklebones/worker exec wrangler d1 migrations apply PLAYERS_DB --env production --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_D1_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+
       - name: Deploy Production
         uses: cloudflare/wrangler-action@v3
         with:

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -35,6 +35,12 @@ jobs:
 
       - run: pnpm test:e2e
 
+      - name: Apply staging database migrations
+        run: pnpm --filter @knucklebones/worker exec wrangler d1 migrations apply PLAYERS_DB --env staging --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_D1_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+
       - name: Deploy Staging
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
## Summary

- apply staging D1 migrations before deploying the staging Worker
- apply production D1 migrations before deploying the production Worker
- use a dedicated least-privilege GitHub Actions secret for database access