### PR TITLE
test(e2e): cover remaining game flows

### DIFF
--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -125,6 +125,29 @@ test('starts a hard BO1 AI game with valid versioned state updates', async ({
       )
     }
   }
+
+  const messagesBeforeReload = gameStateMessages.length
+  const latestMessage = gameStateMessages.at(-1)!
+  const revisionBeforeReload = (
+    (latestMessage.payload as Record<string, unknown>).gameState as Record<
+      string,
+      unknown
+    >
+  ).revision
+
+  await page.reload()
+  await expect(page.getByText('Round 1 of 1')).toBeVisible()
+  await expect(columns).toHaveCount(3)
+  await expect
+    .poll(() => gameStateMessages.length)
+    .toBeGreaterThan(messagesBeforeReload)
+  await page.waitForTimeout(500)
+
+  for (const message of gameStateMessages.slice(messagesBeforeReload)) {
+    const gameState = (message.payload as Record<string, unknown>)
+      .gameState as Record<string, unknown>
+    expect(gameState.revision).toBe(revisionBeforeReload)
+  }
 })
 
 test('synchronizes a human game across independent browser identities', async ({
@@ -181,6 +204,107 @@ test('synchronizes a human game across independent browser identities', async ({
   } finally {
     await firstContext.close()
     await secondContext.close()
+  }
+})
+
+test('keeps spectators read-only across a completed game and rematch', async ({
+  browser
+}) => {
+  test.setTimeout(90_000)
+  const firstContext = await browser.newContext()
+  const secondContext = await browser.newContext()
+  const spectatorContext = await browser.newContext()
+  const firstPlayer = await firstContext.newPage()
+  const secondPlayer = await secondContext.newPage()
+  const spectator = await spectatorContext.newPage()
+  const rematchButton = (page: Page) =>
+    page.getByRole('button', { name: 'Play another game' })
+  const playableColumns = (page: Page) => page.locator('div[role="button"]')
+
+  try {
+    await waitForHome(firstPlayer)
+    await waitForHome(secondPlayer)
+    await waitForHome(spectator)
+    await chooseGame(firstPlayer, 'Play against someone')
+    await firstPlayer.getByRole('radio', { name: 'Best of 1' }).click()
+    await firstPlayer.getByRole('link', { name: 'Start game' }).click()
+    const roomUrl = firstPlayer.url()
+
+    await secondPlayer.goto(roomUrl)
+    for (const page of [firstPlayer, secondPlayer]) {
+      await expect(page.getByText('Waiting for game to start...')).toHaveCount(
+        0
+      )
+      await expect(page.getByText('Round 1 of 1')).toBeVisible()
+    }
+
+    await spectator.goto(roomUrl)
+    await expect(
+      spectator.getByText('Waiting for game to start...')
+    ).toHaveCount(0)
+    await expect(spectator.getByText('Round 1 of 1')).toBeVisible()
+    await expect(playableColumns(spectator)).toHaveCount(0)
+
+    for (let move = 0; move < 20; move++) {
+      if (await rematchButton(firstPlayer).isVisible()) break
+
+      await expect
+        .poll(async () => {
+          if (await rematchButton(firstPlayer).isVisible()) return true
+          const firstCanPlay = (await playableColumns(firstPlayer).count()) > 0
+          const secondCanPlay =
+            (await playableColumns(secondPlayer).count()) > 0
+          return firstCanPlay !== secondCanPlay
+        })
+        .toBe(true)
+      if (await rematchButton(firstPlayer).isVisible()) break
+
+      const currentPlayer =
+        (await playableColumns(firstPlayer).count()) > 0
+          ? firstPlayer
+          : secondPlayer
+      const nextPlayer =
+        currentPlayer === firstPlayer ? secondPlayer : firstPlayer
+      const currentColumns = playableColumns(currentPlayer)
+      const selectedColumn =
+        currentPlayer === firstPlayer
+          ? currentColumns.first()
+          : currentColumns.last()
+      await selectedColumn.dispatchEvent('click')
+      await expect
+        .poll(
+          async () =>
+            (await rematchButton(firstPlayer).isVisible()) ||
+            ((await currentColumns.count()) === 0 &&
+              (await playableColumns(nextPlayer).count()) > 0)
+        )
+        .toBe(true)
+      await expect(playableColumns(spectator)).toHaveCount(0)
+    }
+
+    await expect(rematchButton(firstPlayer)).toBeVisible()
+    await expect(rematchButton(secondPlayer)).toBeVisible()
+    await expect(rematchButton(spectator)).toHaveCount(0)
+
+    await rematchButton(firstPlayer).click()
+    await expect(rematchButton(firstPlayer)).toBeDisabled()
+    await rematchButton(secondPlayer).click()
+
+    await expect(rematchButton(firstPlayer)).toHaveCount(0)
+    await expect(rematchButton(secondPlayer)).toHaveCount(0)
+    await expect
+      .poll(
+        async () =>
+          (await playableColumns(firstPlayer).count()) +
+          (await playableColumns(secondPlayer).count())
+      )
+      .toBeGreaterThan(0)
+    await expect(playableColumns(spectator)).toHaveCount(0)
+    await expect(spectator.getByText('Round 1 of 1')).toBeVisible()
+  } finally {
+    await firstContext.close()
+    await secondContext.close()
+    await spectatorContext.close()
   }
 })
 


### PR DESCRIPTION
## Summary

- verify an AI-room reload does not schedule another authoritative move
- cover a read-only spectator through a complete human BO1
- cover two-player rematch voting while the spectator remains read-only