### PR TITLE
feat(protocol): report sanitized client diagnostics

### DIFF
--- a/apps/front/src/components/GameContext/useGameSetup.test.tsx
+++ b/apps/front/src/components/GameContext/useGameSetup.test.tsx
@@ -10,7 +10,12 @@ import {
   type IGameState
 } from '@knucklebones/common'
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { createWebSocketTicket, initGame, play } from '../../utils/api'
+import {
+  createWebSocketTicket,
+  initGame,
+  play,
+  reportClientProtocolDiagnostic
+} from '../../utils/api'
 import { useGameSetup } from './useGameSetup'
 
 const socket = vi.hoisted(() => ({
@@ -30,6 +35,7 @@ vi.mock('../../utils/api', () => ({
   deleteDisplayName: vi.fn(),
   initGame: vi.fn(),
   play: vi.fn(),
+  reportClientProtocolDiagnostic: vi.fn(),
   updateDisplayName: vi.fn(),
   voteRematch: vi.fn()
 }))
@@ -74,6 +80,9 @@ describe('useGameSetup', () => {
     vi.mocked(createWebSocketTicket).mockReset()
     vi.mocked(initGame).mockReset().mockResolvedValue(undefined)
     vi.mocked(play).mockReset().mockResolvedValue(undefined)
+    vi.mocked(reportClientProtocolDiagnostic)
+      .mockReset()
+      .mockResolvedValue(undefined)
   })
 
   it('ignores stale, foreign-room, and malformed state messages', async () => {
@@ -101,6 +110,11 @@ describe('useGameSetup', () => {
     expect(consoleError).toHaveBeenCalledWith(
       'Ignored an invalid game-state message.'
     )
+    await waitFor(() =>
+      expect(reportClientProtocolDiagnostic).toHaveBeenCalledWith(
+        'INVALID_GAME_STATE_MESSAGE'
+      )
+    )
   })
 
   it('keeps valid state and reports an unsupported protocol version', async () => {
@@ -121,6 +135,11 @@ describe('useGameSetup', () => {
     expect(result.current?.errorMessage).toBe('errors.unsupported-protocol')
     expect(consoleError).toHaveBeenCalledWith(
       'Ignored a message using an unsupported protocol version.'
+    )
+    await waitFor(() =>
+      expect(reportClientProtocolDiagnostic).toHaveBeenCalledWith(
+        'UNSUPPORTED_PROTOCOL_VERSION'
+      )
     )
   })
 

--- a/apps/front/src/components/GameContext/useGameSetup.ts
+++ b/apps/front/src/components/GameContext/useGameSetup.ts
@@ -20,6 +20,7 @@ import {
   updateDisplayName,
   initGame,
   play,
+  reportClientProtocolDiagnostic,
   voteRematch
 } from '../../utils/api'
 import { getStoredPlayerId } from '../../utils/identityStorage'
@@ -79,6 +80,9 @@ export function useGameSetup() {
         'version' in lastJsonMessage &&
         lastJsonMessage.version !== PROTOCOL_VERSION
       ) {
+        void reportClientProtocolDiagnostic(
+          'UNSUPPORTED_PROTOCOL_VERSION'
+        ).catch(() => undefined)
         console.error(
           'Ignored a message using an unsupported protocol version.'
         )
@@ -122,6 +126,9 @@ export function useGameSetup() {
         compatibleGameStateMessageSchema.safeParse(lastJsonMessage)
 
       if (!parsedGameState.success) {
+        void reportClientProtocolDiagnostic('INVALID_GAME_STATE_MESSAGE').catch(
+          () => undefined
+        )
         console.error('Ignored an invalid game-state message.')
         return
       }

--- a/apps/front/src/utils/api.ts
+++ b/apps/front/src/utils/api.ts
@@ -1,5 +1,6 @@
 import {
   apiErrorBodySchema,
+  type ClientProtocolDiagnosticCode,
   type GameSettings,
   type IdentityRecovery,
   type IdentityRecoveryPhrase,
@@ -71,6 +72,12 @@ export async function verifyPlayer({
   credential
 }: PlayerCredentials): Promise<void> {
   await sendApiRequest('/v1/identity/verify', 'POST', undefined, credential)
+}
+
+export async function reportClientProtocolDiagnostic(
+  code: ClientProtocolDiagnosticCode
+): Promise<void> {
+  await sendApiRequest('/v1/diagnostics/protocol', 'POST', { code })
 }
 
 export async function createIdentityTransfer(): Promise<IdentityTransfer> {

--- a/apps/worker/src/endpoints/clientProtocolDiagnostic.ts
+++ b/apps/worker/src/endpoints/clientProtocolDiagnostic.ts
@@ -1,0 +1,59 @@
+import { status } from 'itty-router'
+import { Toucan } from 'toucan-js'
+import { clientProtocolDiagnosticSchema } from '@knucklebones/common'
+import { type CloudflareEnvironment } from '../types/cloudflareEnvironment'
+import { type AuthenticatedRequestWithProps } from '../types/itty'
+import { apiError, sanitizeRequestForSentry } from '../utils/http'
+import { recordOperationalEvent } from '../utils/observability'
+import { enforceRateLimit } from '../utils/rateLimit'
+
+export async function reportClientProtocolDiagnostic(
+  request: Request & AuthenticatedRequestWithProps,
+  cloudflareEnvironment: CloudflareEnvironment,
+  context: ExecutionContext
+): Promise<Response> {
+  const diagnostic = clientProtocolDiagnosticSchema.safeParse(
+    await request.json().catch(() => undefined)
+  )
+  if (!diagnostic.success) {
+    return apiError({
+      status: 400,
+      code: 'INVALID_CLIENT_DIAGNOSTIC',
+      message: 'The client diagnostic is invalid.',
+      requestId: request.requestId
+    })
+  }
+
+  const rateLimit = await enforceRateLimit(
+    request,
+    cloudflareEnvironment.PLAYERS_DB,
+    {
+      scope: 'client-protocol-diagnostic',
+      identifier: request.principal.playerId,
+      limit: 10,
+      windowMs: 60 * 1000
+    }
+  )
+  if (rateLimit !== undefined) {
+    return rateLimit
+  }
+
+  const sentry = new Toucan({
+    dsn: cloudflareEnvironment.SENTRY_DSN,
+    context,
+    request: sanitizeRequestForSentry(request, request.requestId)
+  })
+  sentry.setTag('request_id', request.requestId)
+  sentry.setTag('client_diagnostic_code', diagnostic.data.code)
+  sentry.captureMessage(
+    `Client protocol diagnostic: ${diagnostic.data.code}.`,
+    'warning'
+  )
+  recordOperationalEvent(cloudflareEnvironment.ENVIRONMENT, {
+    event: 'client.protocol-diagnostic',
+    outcome: 'reported',
+    code: diagnostic.data.code
+  })
+
+  return status(204)
+}

--- a/apps/worker/src/endpoints/index.ts
+++ b/apps/worker/src/endpoints/index.ts
@@ -1,3 +1,4 @@
+export * from './clientProtocolDiagnostic'
 export * from './createPlayer'
 export * from './displayName'
 export * from './getRankedProfile'

--- a/apps/worker/src/utils/observability.ts
+++ b/apps/worker/src/utils/observability.ts
@@ -64,6 +64,10 @@ export function classifyRoute(pathname: string): string {
     return `/${segments.join('/')}`
   }
 
+  if (segments[0] === 'v1' && segments[1] === 'diagnostics') {
+    return '/v1/diagnostics/:type'
+  }
+
   if (
     segments[0] === 'v1' &&
     (segments[1] === 'matchmaking' || segments[1] === 'ranked')

--- a/apps/worker/src/utils/validation.ts
+++ b/apps/worker/src/utils/validation.ts
@@ -49,6 +49,10 @@ export function validateRequestPath(
     return
   }
 
+  if (segments[0] === 'v1' && segments[1] === 'diagnostics') {
+    return
+  }
+
   if (
     segments[0] === 'v1' &&
     (segments[1] === 'matchmaking' || segments[1] === 'ranked')

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -17,6 +17,7 @@ import {
   listDeviceCredentials,
   play,
   playIntent,
+  reportClientProtocolDiagnostic,
   rematch,
   rematchRoom,
   redeemIdentityTransfer,
@@ -57,6 +58,8 @@ router
   .post('/players', createPlayer)
   .post('/v1/identity/transfers/redeem', redeemIdentityTransfer)
   .post('/v1/identity/recovery/redeem', redeemIdentityRecovery)
+  .all('/v1/diagnostics/*', authenticatePlayerRequest)
+  .post('/v1/diagnostics/protocol', reportClientProtocolDiagnostic)
   .all('/v1/identity/*', authenticatePlayerRequest)
   .post('/v1/identity/verify', verifyPlayer)
   .post('/v1/identity/transfers', createIdentityTransfer)

--- a/apps/worker/test/observability.test.ts
+++ b/apps/worker/test/observability.test.ts
@@ -15,6 +15,9 @@ describe('operational events', () => {
         '/v1/identity/credentials/22222222-2222-4222-8222-222222222222'
       )
     ).toBe('/v1/identity/credentials/:credentialId')
+    expect(classifyRoute('/v1/diagnostics/protocol')).toBe(
+      '/v1/diagnostics/:type'
+    )
   })
 
   it('logs structured outcomes without request secrets', () => {

--- a/apps/worker/test/worker.integration.test.ts
+++ b/apps/worker/test/worker.integration.test.ts
@@ -860,29 +860,29 @@ describe('runtime request validation', () => {
       'Idempotency-Key': crypto.randomUUID()
     }
 
-    const invalidRoom = await request(`/not-a-room/${player.playerId}/init`, {
-      method: 'POST',
-      headers
-    })
-    const invalidSettings = await request(
-      `/${roomKey}/${player.playerId}/init?boType=2`,
-      { method: 'POST', headers }
-    )
-    const invalidMove = await request(
-      `/${roomKey}/${player.playerId}/play/3/4.5`,
-      { method: 'POST', headers }
-    )
-    const blankDisplayName = await request(
-      `/${roomKey}/${player.playerId}/displayName/%20`,
-      { method: 'POST', headers }
-    )
-
-    for (const [label, response, code] of [
-      ['invalid room', invalidRoom, 'INVALID_ROUTE_PARAMETERS'],
-      ['invalid settings', invalidSettings, 'INVALID_GAME_SETTINGS'],
-      ['invalid move', invalidMove, 'INVALID_ROUTE_PARAMETERS'],
-      ['blank display name', blankDisplayName, 'INVALID_ROUTE_PARAMETERS']
+    for (const [label, path, code] of [
+      [
+        'invalid room',
+        `/not-a-room/${player.playerId}/init`,
+        'INVALID_ROUTE_PARAMETERS'
+      ],
+      [
+        'invalid settings',
+        `/${roomKey}/${player.playerId}/init?boType=2`,
+        'INVALID_GAME_SETTINGS'
+      ],
+      [
+        'invalid move',
+        `/${roomKey}/${player.playerId}/play/3/4.5`,
+        'INVALID_ROUTE_PARAMETERS'
+      ],
+      [
+        'blank display name',
+        `/${roomKey}/${player.playerId}/displayName/%20`,
+        'INVALID_ROUTE_PARAMETERS'
+      ]
     ] as const) {
+      const response = await request(path, { method: 'POST', headers })
       const responseText = await response.text()
       expect(response.status, `${label}: ${responseText}`).toBe(400)
       const body = apiErrorBodySchema.parse(JSON.parse(responseText))

--- a/apps/worker/test/worker.integration.test.ts
+++ b/apps/worker/test/worker.integration.test.ts
@@ -95,6 +95,38 @@ describe('environment request policy', () => {
   })
 })
 
+describe('client protocol diagnostics', () => {
+  it('accepts only authenticated fixed diagnostic codes', async () => {
+    const player = await createPlayer()
+    const diagnostic = { code: 'INVALID_GAME_STATE_MESSAGE' }
+    const missingCredential = await request('/v1/diagnostics/protocol', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(diagnostic)
+    })
+    const invalid = await request('/v1/diagnostics/protocol', {
+      method: 'POST',
+      headers: {
+        ...authorization(player),
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ code: 'RAW_PAYLOAD', payload: 'secret' })
+    })
+    const valid = await request('/v1/diagnostics/protocol', {
+      method: 'POST',
+      headers: {
+        ...authorization(player),
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(diagnostic)
+    })
+
+    expect(missingCredential.status).toBe(401)
+    expect(invalid.status).toBe(400)
+    expect(valid.status).toBe(204)
+  })
+})
+
 describe('player identities and ranked profiles', () => {
   it('creates an authenticated UUID identity with a default rating', async () => {
     const player = await createPlayer()

--- a/packages/common/src/schemas/api.ts
+++ b/packages/common/src/schemas/api.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod/mini'
-import { type ApiErrorBody } from '../types'
+import { type ApiErrorBody, type ClientProtocolDiagnostic } from '../types'
 import { boTypeSchema, difficultySchema } from './gameState'
 import {
   displayNameSchema,
@@ -18,6 +18,10 @@ export const apiErrorDetailsSchema = z.object({
 export const apiErrorBodySchema = z.object({
   error: apiErrorDetailsSchema
 }) satisfies z.ZodMiniType<ApiErrorBody>
+
+export const clientProtocolDiagnosticSchema = z.strictObject({
+  code: z.enum(['INVALID_GAME_STATE_MESSAGE', 'UNSUPPORTED_PROTOCOL_VERSION'])
+}) satisfies z.ZodMiniType<ClientProtocolDiagnostic>
 
 export const playerRouteParamsSchema = z.object({
   playerId: playerIdSchema

--- a/packages/common/src/types/protocol.ts
+++ b/packages/common/src/types/protocol.ts
@@ -20,6 +20,13 @@ export interface ApiErrorBody {
   error: ApiErrorDetails
 }
 
+export type ClientProtocolDiagnosticCode =
+  'INVALID_GAME_STATE_MESSAGE' | 'UNSUPPORTED_PROTOCOL_VERSION'
+
+export interface ClientProtocolDiagnostic {
+  code: ClientProtocolDiagnosticCode
+}
+
 export interface GameStateEventPayload {
   roomKey: string
   gameState: IGameState


### PR DESCRIPTION
## Summary

- report malformed and unsupported game messages through an authenticated protocol-diagnostic endpoint
- accept only fixed diagnostic codes and never send raw WebSocket payloads
- rate-limit reports and sanitize Sentry request context
- cover frontend reporting, runtime validation, authentication, and normalized observability