### PR TITLE
test(game): make flow coverage deterministic

### DIFF
--- a/apps/worker/test/worker.integration.test.ts
+++ b/apps/worker/test/worker.integration.test.ts
@@ -674,7 +674,7 @@ describe('versioned authenticated room API', () => {
     }
   })
 
-  it('rejects rematch votes from authenticated spectators', async () => {
+  it('accepts both player rematch votes but rejects authenticated spectators', async () => {
     const playerOne = await createPlayer()
     const playerTwo = await createPlayer()
     const spectator = await createPlayer()
@@ -732,6 +732,42 @@ describe('versioned authenticated room API', () => {
     await expect(displayName.json()).resolves.toMatchObject({
       error: { code: 'NOT_A_PLAYER' }
     })
+
+    const firstVote = await request(
+      `/v1/rooms/${roomKey}/rematch`,
+      mutationRequest(playerOne, {})
+    )
+    const secondVote = await request(
+      `/v1/rooms/${roomKey}/rematch`,
+      mutationRequest(playerTwo, {})
+    )
+    expect(firstVote.status).toBe(200)
+    expect(secondVote.status).toBe(200)
+
+    const currentStateResponse = await callGame('initializeGame', [
+      {
+        mutationId: crypto.randomUUID(),
+        playerId: playerOne.playerId,
+        boType: 1
+      }
+    ])
+    const currentState = idempotentInitializeGameResultSchema.parse(
+      await currentStateResponse.json()
+    )
+    expect(currentState.idempotencyStatus).toBe('applied')
+    if (
+      currentState.idempotencyStatus !== 'conflict' &&
+      currentState.value.status === 'existing'
+    ) {
+      expect(currentState.value.gameState).toMatchObject({
+        outcome: 'ongoing',
+        playerOne: { id: playerOne.playerId },
+        playerTwo: { id: playerTwo.playerId }
+      })
+      expect(currentState.value.gameState.rematchVote).toBeUndefined()
+    } else {
+      throw new Error('Expected the rematch to create an ongoing game.')
+    }
   })
 })
 

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -207,18 +207,15 @@ test('synchronizes a human game across independent browser identities', async ({
   }
 })
 
-test('keeps spectators read-only across a completed game and rematch', async ({
+test('keeps a spectator read-only while synchronizing a human move', async ({
   browser
 }) => {
-  test.setTimeout(90_000)
   const firstContext = await browser.newContext()
   const secondContext = await browser.newContext()
   const spectatorContext = await browser.newContext()
   const firstPlayer = await firstContext.newPage()
   const secondPlayer = await secondContext.newPage()
   const spectator = await spectatorContext.newPage()
-  const rematchButton = (page: Page) =>
-    page.getByRole('button', { name: 'Play another game' })
   const playableColumns = (page: Page) => page.locator('div[role="button"]')
 
   try {
@@ -245,62 +242,26 @@ test('keeps spectators read-only across a completed game and rematch', async ({
     await expect(spectator.getByText('Round 1 of 1')).toBeVisible()
     await expect(playableColumns(spectator)).toHaveCount(0)
 
-    for (let move = 0; move < 20; move++) {
-      if (await rematchButton(firstPlayer).isVisible()) break
-
-      await expect
-        .poll(async () => {
-          if (await rematchButton(firstPlayer).isVisible()) return true
-          const firstCanPlay = (await playableColumns(firstPlayer).count()) > 0
-          const secondCanPlay =
-            (await playableColumns(secondPlayer).count()) > 0
-          return firstCanPlay !== secondCanPlay
-        })
-        .toBe(true)
-      if (await rematchButton(firstPlayer).isVisible()) break
-
-      const currentPlayer =
-        (await playableColumns(firstPlayer).count()) > 0
-          ? firstPlayer
-          : secondPlayer
-      const nextPlayer =
-        currentPlayer === firstPlayer ? secondPlayer : firstPlayer
-      const currentColumns = playableColumns(currentPlayer)
-      const selectedColumn =
-        currentPlayer === firstPlayer
-          ? currentColumns.first()
-          : currentColumns.last()
-      await selectedColumn.dispatchEvent('click')
-      await expect
-        .poll(
-          async () =>
-            (await rematchButton(firstPlayer).isVisible()) ||
-            ((await currentColumns.count()) === 0 &&
-              (await playableColumns(nextPlayer).count()) > 0)
-        )
-        .toBe(true)
-      await expect(playableColumns(spectator)).toHaveCount(0)
-    }
-
-    await expect(rematchButton(firstPlayer)).toBeVisible()
-    await expect(rematchButton(secondPlayer)).toBeVisible()
-    await expect(rematchButton(spectator)).toHaveCount(0)
-
-    await rematchButton(firstPlayer).click()
-    await expect(rematchButton(firstPlayer)).toBeDisabled()
-    await rematchButton(secondPlayer).click()
-
-    await expect(rematchButton(firstPlayer)).toHaveCount(0)
-    await expect(rematchButton(secondPlayer)).toHaveCount(0)
     await expect
       .poll(
         async () =>
           (await playableColumns(firstPlayer).count()) +
           (await playableColumns(secondPlayer).count())
       )
-      .toBeGreaterThan(0)
+      .toBe(3)
+
+    const currentPlayer =
+      (await playableColumns(firstPlayer).count()) === 3
+        ? firstPlayer
+        : secondPlayer
+    const nextPlayer =
+      currentPlayer === firstPlayer ? secondPlayer : firstPlayer
+    await playableColumns(currentPlayer).first().dispatchEvent('click')
+
+    await expect(playableColumns(currentPlayer)).toHaveCount(0)
+    await expect(playableColumns(nextPlayer)).toHaveCount(3)
     await expect(playableColumns(spectator)).toHaveCount(0)
-    await expect(spectator.getByText('Round 1 of 1')).toBeVisible()
+    await expect(spectator.getByText(/^Total: [1-6]$/)).toBeVisible()
   } finally {
     await firstContext.close()
     await secondContext.close()


### PR DESCRIPTION
## Summary

- verify live spectators remain read-only while receiving a synchronized move
- verify both authenticated players can complete a rematch after an authoritative terminal outcome
- remove the invalid assumption that a random Knucklebones game always ends within 20 moves